### PR TITLE
Make node dimensions fill their containers

### DIFF
--- a/src/components/common/SelectDropdown.tsx
+++ b/src/components/common/SelectDropdown.tsx
@@ -209,11 +209,11 @@ function SelectDropdown<
   IsMulti extends boolean = false,
   Group extends GroupBase<Option> = GroupBase<Option>
 >(props: SelectDropdownProps<Option, IsMulti, Group>) {
-  const { size, id, label, value, onChange, helpText, invert, isMulti, ...rest } = props;
+  const { size, id, label, value, onChange, helpText, invert, isMulti, className, ...rest } = props;
   const theme = useTheme();
   const styles = getSelectStyles<Option, IsMulti, Group>(theme, props.isMulti === true, size);
   return (
-    <FormGroup>
+    <FormGroup className={className}>
       { label && (
         <Label for={id}>
           { label }

--- a/src/components/general/DimensionalNodePlot.tsx
+++ b/src/components/general/DimensionalNodePlot.tsx
@@ -308,6 +308,7 @@ export default function DimensionalNodePlot(props: DimensionalNodePlotProps) {
       <Col md={3} className="d-flex" key="dimension">
         <SelectDropdown
           id="dimension"
+          className='flex-grow-1'
           label={t('plot-choose-dimension')!}
           onChange={val => setSliceConfig(old => ({...old, dimensionId: val?.id || undefined}))}
           options={sliceableDims}
@@ -323,6 +324,7 @@ export default function DimensionalNodePlot(props: DimensionalNodePlotProps) {
         <Col md={4} className="d-flex" key={dim.id}>
           <SelectDropdown
             id={`dim-${dim.id}`}
+            className='flex-grow-1'
             label={dim.label}
             options={options}
             value={options.filter(opt => opt.selected)}


### PR DESCRIPTION
Previously component widths were determined by the label content, this change stretches node dimension dropdowns to full width.

### Previous
<img width="1319" alt="Screenshot 2023-08-21 at 14 52 30" src="https://github.com/kausaltech/kausal-paths-ui/assets/15343658/61bad20f-8d4c-42c3-9744-68cc269e2b3f">

### Updated
<img width="1320" alt="Screenshot 2023-08-21 at 14 50 15" src="https://github.com/kausaltech/kausal-paths-ui/assets/15343658/6583b084-2c4b-47f3-aeb0-4cb4133cecc0">
