### PR TITLE
Fix a few typescript, linter and console errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "graphql-codegen": "graphql-codegen --config codegen.ts",
-    "prettier:fix": "prettier ./ --write"
+    "prettier:fix": "prettier ./ --write",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@apollo/client": "^3.8.0-rc.2",

--- a/src/components/general/ActionsList.tsx
+++ b/src/components/general/ActionsList.tsx
@@ -60,8 +60,8 @@ const ActionsList = (props: ActionsListProps) => {
   }, [actions, sortBy, sortAscending]);
 
   // Group actions by group
-  const actionGroups = useMemo(() => {
-    const groups = new Set();
+  const actionGroups = useMemo<string[]>(() => {
+    const groups = new Set<string>();
     actions.forEach((action) => {
       if (action.group) groups.add(action.group.name);
     });
@@ -72,7 +72,7 @@ const ActionsList = (props: ActionsListProps) => {
   return (
     <div>
       {actionGroups?.map((group) => (
-        <div>
+        <div key={group}>
           <ActionListCategory>
             <h3>{group}</h3>
           </ActionListCategory>

--- a/src/components/general/ActionsSummary.tsx
+++ b/src/components/general/ActionsSummary.tsx
@@ -37,17 +37,17 @@ const ActionsListItem = styled.div`
   flex: 1 1 320px;
 `;
 
-const ActionCard = styled.div<{ active: boolean; groupColor: string }>`
+const ActionCard = styled.div<{ $isActive: boolean; $groupColor: string }>`
   position: relative;
   flex: 1 1 320px;
   min-height: 3rem;
   height: 100%;
   padding: 0.25rem 0.5rem 0.25rem 1rem;
   border: 1px solid ${(props) => props.theme.graphColors.grey010};
-  border-left: 4px solid ${(props) => props.groupColor};
+  border-left: 4px solid ${(props) => props.$groupColor};
   border-radius: 0.25rem;
   background-color: ${(props) =>
-    props.active
+    props.$isActive
       ? props.theme.themeColors.white
       : props.theme.graphColors.grey010};
 
@@ -65,7 +65,7 @@ const ActionCard = styled.div<{ active: boolean; groupColor: string }>`
   a,
   a > h6 {
     color: ${(props) =>
-      props.active
+      props.$isActive
         ? props.theme.graphColors.grey090
         : props.theme.graphColors.grey050};
   }
@@ -195,7 +195,7 @@ const ActionListCard = (props) => {
   );
 
   return (
-    <ActionCard active={isActive} groupColor={action.group?.color}>
+    <ActionCard $isActive={isActive} $groupColor={action.group?.color}>
       <small>{action.group?.name}</small>
       <h5>{action.name}</h5>
       {actionParameterSwitch && (

--- a/src/components/general/OutcomeNodeDetails.tsx
+++ b/src/components/general/OutcomeNodeDetails.tsx
@@ -17,14 +17,14 @@ const ActionGroup = styled.p`
   font-size: 0.8rem;
 `;
 
-const ActionsListCard = styled.li<{ active: boolean; groupColor: string }>`
+const ActionsListCard = styled.li<{ active: boolean; $groupColor: string }>`
   position: relative;
   flex: 1 1 320px;
   min-height: 3rem;
   padding: 0.25rem 0.5rem;
   margin: 0.5rem;
   border: 1px solid ${(props) => props.theme.graphColors.grey010};
-  border-left: 4px solid ${(props) => props.groupColor};
+  border-left: 4px solid ${(props) => props.$groupColor};
   border-radius: 0.25rem;
 
   &:hover {
@@ -56,7 +56,7 @@ const ActionListItem = (props) => {
 
   // console.log("ActionListItem", props, isActive)
   return (
-    <ActionsListCard active={isActive} groupColor={color}>
+    <ActionsListCard active={isActive} $groupColor={color}>
       <ActionLink action={action}>
         <a>
           {action.group && <ActionGroup>{action.group.name}</ActionGroup>}

--- a/src/pages/node/[slug].tsx
+++ b/src/pages/node/[slug].tsx
@@ -22,11 +22,11 @@ import { GetNodePageQuery } from 'common/__generated__/graphql';
 import ErrorMessage from 'components/common/ErrorMessage';
 import dimensionalNodePlotFragment from 'queries/dimensionalNodePlot';
 
-const HeaderSection = styled.div`
+const HeaderSection = styled.div<{ $color?: string }>`
   padding: 1rem 0 1rem;
   margin-bottom: 7rem;
   background-color: ${(props) =>
-    props.color || props.theme.graphColors.grey070};
+    props.$color || props.theme.graphColors.grey070};
 `;
 
 const PageHeader = styled.div`
@@ -183,17 +183,19 @@ export default function NodePage() {
           {site.title} | {node.name}
         </title>
       </Head>
-      <HeaderSection color={node.color}>
+      <HeaderSection $color={node.color || undefined}>
         <Container fluid="lg">
           <PageHeader>
             <HeaderCard>
               <div>{node.isAction && <span>{t('action')}</span>}</div>
               <h1>{node.name}</h1>
-              <NodeDescription>
-                <div
-                  dangerouslySetInnerHTML={{ __html: node.shortDescription }}
-                />
-              </NodeDescription>
+              {node.shortDescription && (
+                <NodeDescription>
+                  <div
+                    dangerouslySetInnerHTML={{ __html: node.shortDescription }}
+                  />
+                </NodeDescription>
+              )}
               <div>
                 {node.isAction && (
                   <ActionLink action={node}>


### PR DESCRIPTION
Just a few non-user facing fixes after clicking around yesterday. The new `$` props on styled components are [transient props](https://styled-components.com/docs/api#transient-props), which prevent the prop being passed to the dom element and raising console errors