### PR TITLE
Remove unused variable

### DIFF
--- a/src/components/general/OutcomeCard.tsx
+++ b/src/components/general/OutcomeCard.tsx
@@ -180,7 +180,6 @@ const OutcomeCard = (props: OutcomeCardProps) => {
   const change = getMetricChange(baseOutcomeValue, goalOutcomeValue);
   const lastMeasuredYear =
     node?.metric.historicalValues[node.metric.historicalValues.length - 1].year;
-  const firstForecastYear = node?.metric.forecastValues[0].year;
   const isForecast = endYear > lastMeasuredYear;
 
   // const unit = `kt CO<sub>2</sub>e${t('abbr-per-annum')}`;


### PR DESCRIPTION
Should fix the following error discovered by @mechenich. `firstForecastYear` isn't used in this context.

![Screenshot 2023-10-03 at 18 29 11](https://github.com/kausaltech/kausal-paths-ui/assets/15343658/86e94414-5058-4d57-a413-75171fe0d773)
