### PR TITLE
fix: ensure there are forecast values to avoid uncaught errors

### DIFF
--- a/src/components/general/OutcomeNodeContent.tsx
+++ b/src/components/general/OutcomeNodeContent.tsx
@@ -134,7 +134,7 @@ const OutcomeNodeContent = (props: OutcomeNodeContentProps) => {
   const nodesBase = getMetricValue(node, startYear);
   const lastMeasuredYear =
     node?.metric.historicalValues[node.metric.historicalValues.length - 1].year;
-  const firstForecastYear = node?.metric.forecastValues[0].year;
+  const firstForecastYear = node?.metric?.forecastValues[0]?.year;
   const isForecast = endYear > lastMeasuredYear;
   const outcomeChange = getMetricChange(nodesBase, nodesTotal);
 
@@ -186,12 +186,13 @@ const OutcomeNodeContent = (props: OutcomeNodeContentProps) => {
                   {startYear}—{lastMeasuredYear} {t('table-historical')}
                 </ScenarioBadge>
               )}{' '}
-              {firstForecastYear < endYear && (
-                <ScenarioBadge type="activeScenario">
-                  {Math.max(startYear, firstForecastYear)}—{endYear}{' '}
-                  {t('table-scenario-forecast')} {activeScenario || 'Current'}
-                </ScenarioBadge>
-              )}
+              {typeof firstForecastYear === 'number' &&
+                firstForecastYear < endYear && (
+                  <ScenarioBadge type="activeScenario">
+                    {Math.max(startYear, firstForecastYear)}—{endYear}{' '}
+                    {t('table-scenario-forecast')} {activeScenario || 'Current'}
+                  </ScenarioBadge>
+                )}
             </CardSetDescriptionDetails>
           </CardSetDescription>
         </div>


### PR DESCRIPTION
Hide the "Scenario forecast" badge when no forecast values exist. Fixes the second error (similar to #41) discovered by @mechenich.

![Screenshot 2023-10-05 at 9 13 07](https://github.com/kausaltech/kausal-paths-ui/assets/15343658/160fb242-b896-42ba-9c1c-0dce95f044e7)