### PR TITLE
Migrate text and colours to new theme variables

### DIFF
--- a/src/components/general/ActionListCard.tsx
+++ b/src/components/general/ActionListCard.tsx
@@ -9,18 +9,14 @@ import Badge from 'components/common/Badge';
 import EfficiencyDisplay from 'components/general/EfficiencyDisplay';
 import { ActionWithEfficiency } from 'components/pages/ActionListPage';
 
-const ActionItem = styled.div<{ isActive: boolean; color?: string }>`
+const ActionItem = styled.div<{ $isActive: boolean; color?: string }>`
   position: relative;
   margin-bottom: 0.5rem;
-  color: ${(props) =>
-    props.isActive
-      ? props.theme.graphColors.grey090
-      : props.theme.graphColors.grey050};
+  color: ${({ $isActive, theme }) =>
+    $isActive ? theme.textColor.secondary : theme.textColor.tertiary};
   padding: 1rem;
-  background-color: ${(props) =>
-    props.isActive
-      ? props.theme.themeColors.white
-      : props.theme.graphColors.grey005};
+  background-color: ${({ $isActive, theme }) =>
+    $isActive ? theme.cardBackground.primary : theme.cardBackground.secondary};
   box-shadow: 3px 3px 12px rgba(33, 33, 33, 0.15);
   border-left: 6px solid
     ${(props) =>
@@ -29,10 +25,8 @@ const ActionItem = styled.div<{ isActive: boolean; color?: string }>`
         : props.theme.graphColors.grey090};
 
   h5 {
-    color: ${(props) =>
-      props.isActive
-        ? props.theme.graphColors.grey090
-        : props.theme.graphColors.grey050};
+    color: ${({ $isActive, theme }) =>
+      $isActive ? theme.textColor.secondary : theme.textColor.tertiary};
   }
 `;
 
@@ -133,7 +127,7 @@ const ActionListCard = (props: ActionListCardProps) => {
   return (
     <ActionItem
       key={action.id}
-      isActive={isActive}
+      $isActive={isActive}
       color={action.group?.color ?? 'undefined'}
     >
       {refetching && (

--- a/src/components/general/ActionListCard.tsx
+++ b/src/components/general/ActionListCard.tsx
@@ -26,7 +26,7 @@ const ActionItem = styled.div<{ $isActive: boolean; color?: string }>`
 
   h5 {
     color: ${({ $isActive, theme }) =>
-      $isActive ? theme.textColor.secondary : theme.textColor.tertiary};
+      $isActive ? theme.textColor.primary : theme.textColor.tertiary};
   }
 `;
 

--- a/src/components/general/ActionsList.tsx
+++ b/src/components/general/ActionsList.tsx
@@ -19,7 +19,7 @@ const ActionListItem = styled(Col)`
 const ActionListCategory = styled.div`
   padding: ${(props) => props.theme.spaces.s100};
   margin-bottom: ${(props) => props.theme.spaces.s200};
-  background-color: ${(props) => props.theme.graphColors.grey000};
+  background-color: ${({ theme }) => theme.cardBackground.secondary};
 
   h3 {
     margin: 0;

--- a/src/components/general/ActionsList.tsx
+++ b/src/components/general/ActionsList.tsx
@@ -19,7 +19,7 @@ const ActionListItem = styled(Col)`
 const ActionListCategory = styled.div`
   padding: ${(props) => props.theme.spaces.s100};
   margin-bottom: ${(props) => props.theme.spaces.s200};
-  background-color: ${({ theme }) => theme.cardBackground.secondary};
+  background-color: ${({ theme }) => theme.cardBackground.primary};
 
   h3 {
     margin: 0;

--- a/src/components/general/CausalCard.tsx
+++ b/src/components/general/CausalCard.tsx
@@ -22,7 +22,7 @@ const NodeCard = styled.div`
   box-shadow: 3px 3px 12px rgba(33, 33, 33, 0.15);
   max-width: 400px;
   padding: 1rem;
-  background-color: ${(props) => props.theme.graphColors.grey005};
+  background-color: ${({ theme }) => theme.cardBackground.secondary};
   white-space: normal;
 
   &.type-action .card {
@@ -65,7 +65,7 @@ const CardHeader = styled.div`
 `;
 
 const ContentWrapper = styled.div`
-  background-color: ${(props) => props.theme.graphColors.grey005};
+  background-color: ${({ theme }) => theme.cardBackground.secondary};
   border-radius: 0;
 
   .x2sstick text,

--- a/src/components/general/CausalGrid.tsx
+++ b/src/components/general/CausalGrid.tsx
@@ -115,7 +115,7 @@ const PageHeader = styled.div`
 const ContentWrapper = styled.div`
   padding: 1rem;
   margin: 0.5rem 0;
-  background-color: ${(props) => props.theme.graphColors.grey005};
+  background-color: ${({ theme }) => theme.cardBackground.secondary};
   border-radius: 0;
 
   .x2sstick text,

--- a/src/components/general/DashCard.tsx
+++ b/src/components/general/DashCard.tsx
@@ -18,30 +18,30 @@ const CardWithState = styled.div`
 
   &.open,
   &.root {
-    color: ${(props) => props.theme.graphColors.grey050};
+    color: ${({ theme }) => theme.textColor.tertiary};
     background-color: white;
 
     h2 {
-      color: ${(props) => props.theme.graphColors.grey050};
+      color: ${({ theme }) => theme.textColor.tertiary};
     }
   }
 
   &.inactive,
   &.closed {
-    color: ${(props) => props.theme.graphColors.grey090};
+    color: ${({ theme }) => theme.textColor.secondary};
     background-color: white;
 
     h2 {
-      color: ${(props) => props.theme.graphColors.grey090};
+      color: ${({ theme }) => theme.textColor.secondary};
     }
   }
 
   &.open.hovered {
-    color: ${(props) => props.theme.graphColors.grey090};
+    color: ${({ theme }) => theme.textColor.secondary};
     //border-color: ${(props) => props.color};
 
     h2 {
-      color: ${(props) => props.theme.graphColors.grey070};
+      color: ${({ theme }) => theme.textColor.secondary};
     }
 
     &::after {
@@ -62,8 +62,8 @@ const CardWithState = styled.div`
   &.active.open,
   &.root {
     position: relative;
-    color: ${(props) => props.theme.graphColors.grey090};
-    background-color: ${(props) => props.theme.graphColors.grey005};
+    color: ${({ theme }) => theme.textColor.secondary};
+    background-color: ${({ theme }) => theme.cardBackground.secondary};
     // border-radius: ${(props) => props.theme.cardBorderRadius} ${(props) =>
       props.theme.cardBorderRadius} 0 0;
     height: 206px;
@@ -71,7 +71,7 @@ const CardWithState = styled.div`
     box-shadow: 3px 3px 12px rgba(33, 33, 33, 0.15);
 
     h2 {
-      color: ${(props) => props.theme.graphColors.grey090};
+      color: ${({ theme }) => theme.textColor.secondary};
     }
   }
 `;

--- a/src/components/general/HighlightValue.tsx
+++ b/src/components/general/HighlightValue.tsx
@@ -30,7 +30,7 @@ const TotalUnit = styled.span<{ $size?: string }>`
 const YearRange = styled.div<{ $size?: string }>`
   display: flex;
   font-size: ${({ $size }) => ($size === 'sm' ? '0.6' : '0.75')}rem;
-  color: ${({ theme }) => theme.textColor.tertiary};
+  color: ${({ theme }) => theme.textColor.secondary};
 `;
 
 type HighlightValueProps = {

--- a/src/components/general/HighlightValue.tsx
+++ b/src/components/general/HighlightValue.tsx
@@ -1,38 +1,36 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 
-const TotalValue = styled.div<{ muted?: boolean; size?: string }>`
-  padding: 0;
+const TotalValue = styled.div<{ $size?: string; $muted?: boolean }>`
+  padding: 0rem;
   line-height: 1.2;
   font-weight: 700;
-  font-size: ${(props) => (props.size === 'sm' ? '1.25' : '1.5')}rem;
-  color: ${(props) =>
-    props.muted
-      ? props.theme.graphColors.grey050
-      : props.theme.graphColors.grey090};
+  font-size: ${({ $size }) => ($size === 'sm' ? '1.25' : '1.5')}rem;
+  color: ${({ $muted, theme }) =>
+    $muted ? theme.textColor.tertiary : theme.textColor.secondary};
 
   &:hover {
-    color: ${(props) => props.theme.graphColors.grey090};
-    cursor: pointer;
+    color: ${({ theme }) => theme.textColor.secondary};
 
     > div {
-      color: ${(props) => props.theme.graphColors.grey090};
+      color: ${({ theme }) => theme.textColor.secondary};
     }
+
     svg {
-      fill: ${(props) => props.theme.graphColors.grey090};
+      fill: ${({ theme }) => theme.textColor.secondary};
     }
   }
 `;
 
-const TotalUnit = styled.span<{ size?: string }>`
+const TotalUnit = styled.span<{ $size?: string }>`
   margin-left: 0.25rem;
-  font-size: ${(props) => (props.size === 'sm' ? '0.6' : '0.75')}rem;
+  font-size: ${({ $size }) => ($size === 'sm' ? '0.6' : '0.75')}rem;
 `;
 
-const YearRange = styled.div<{ size?: string }>`
+const YearRange = styled.div<{ $size?: string }>`
   display: flex;
-  font-size: ${(props) => (props.size === 'sm' ? '0.6' : '0.75')}rem;
-  color: ${(props) => props.theme.graphColors.grey070};
+  font-size: ${({ $size }) => ($size === 'sm' ? '0.6' : '0.75')}rem;
+  color: ${({ theme }) => theme.textColor.tertiary};
 `;
 
 type HighlightValueProps = {
@@ -52,12 +50,12 @@ const HighlightValue = (props: HighlightValueProps) => {
   const toggle = () => setTooltipOpen(!tooltipOpen);
 
   return (
-    <TotalValue className={className} size={size} muted={muted} id={id}>
-      <YearRange size={size}>
+    <TotalValue className={className} $size={size} $muted={muted} id={id}>
+      <YearRange $size={size}>
         <span dangerouslySetInnerHTML={{ __html: header }} />
       </YearRange>
       {displayValue}
-      <TotalUnit dangerouslySetInnerHTML={{ __html: unit }} size={size} />
+      <TotalUnit dangerouslySetInnerHTML={{ __html: unit }} $size={size} />
     </TotalValue>
   );
 };

--- a/src/components/general/HighlightValue.tsx
+++ b/src/components/general/HighlightValue.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 const TotalValue = styled.div<{ $size?: string; $muted?: boolean }>`
-  padding: 0rem;
+  padding: 0;
   line-height: 1.2;
   font-weight: 700;
   font-size: ${({ $size }) => ($size === 'sm' ? '1.25' : '1.5')}rem;

--- a/src/components/general/ImpactDisplay.tsx
+++ b/src/components/general/ImpactDisplay.tsx
@@ -11,17 +11,15 @@ const ImpactDisplayWrapper = styled.div`
   border-radius: 0;
 `;
 
-const ImpactDisplayHeader = styled.div`
+const ImpactDisplayHeader = styled.div<{ $muted: boolean }>`
   flex: 0 0 100%;
   padding: 0.5rem;
   border-bottom: 1px solid ${(props) => props.theme.graphColors.grey030};
   line-height: 1;
   font-size: 0.75rem;
   font-weight: 700;
-  color: ${(props) =>
-    props.muted
-      ? props.theme.graphColors.grey050
-      : props.theme.graphColors.grey090};
+  color: ${({ theme, $muted }) =>
+    $muted ? theme.textColor.tertiary : theme.textColor.secondary};
 `;
 
 const ImpactDisplayItem = styled.div`
@@ -83,7 +81,7 @@ const ImpactDisplay = (props: ImpactDisplayProps) => {
 
   return (
     <ImpactDisplayWrapper>
-      <ImpactDisplayHeader muted={muted}>
+      <ImpactDisplayHeader $muted={muted}>
         {t('impact')}
         {impactName && ` (${impactName})`}
       </ImpactDisplayHeader>

--- a/src/components/general/NodeLinks.tsx
+++ b/src/components/general/NodeLinks.tsx
@@ -9,7 +9,7 @@ const InputNodes = styled.div`
   padding: 0.5rem;
   border-radius: 0;
   font-size: 1rem;
-  background-color: ${(props) => props.theme.graphColors.grey005};
+  background-color: ${({ theme }) => theme.cardBackground.secondary};
 
   .list-group-item {
     display: flex;
@@ -27,7 +27,7 @@ const OutputNodes = styled.div`
   padding: 0.5rem;
   border-radius: 0;
   font-size: 1rem;
-  background-color: ${(props) => props.theme.graphColors.grey005};
+  background-color: ${({ theme }) => theme.cardBackground.secondary};
   .list-group-item {
     display: flex;
     flex-direction: row-reverse;

--- a/src/components/general/OutcomeCard.tsx
+++ b/src/components/general/OutcomeCard.tsx
@@ -60,11 +60,10 @@ const Name = styled.h2`
 
 const Status = styled.div`
   margin-top: 0.5rem;
-  //text-align: right;
   white-space: nowrap;
   font-size: 1rem;
   font-weight: 700;
-  color: ${(props) => props.theme.graphColors.grey050};
+  color: ${({ theme }) => theme.textColor.tertiary};
 `;
 
 const Body = styled.div`
@@ -81,10 +80,11 @@ const MainValue = styled.div`
   font-weight: 700;
 `;
 
-const Label = styled.div`
+const Label = styled.div<{ $active?: boolean }>`
   font-size: 0.7rem;
   font-weight: 700;
-  color: ${(props) => props.theme.graphColors.grey050};
+  color: ${({ theme, $active }) =>
+    $active ? theme.textColor.primary : theme.textColor.tertiary};
 `;
 
 const MainUnit = styled.span`
@@ -110,7 +110,6 @@ const ProportionBarContainer = styled.div<{ $active: boolean }>`
   bottom: ${(props) => (props.$active ? '36px' : '0')};
   left: 0;
   width: 12px;
-  // border-right: 1px solid ${(props) => props.theme.graphColors.grey010};
 `;
 
 const ProportionBar = ({
@@ -216,7 +215,7 @@ const OutcomeCard = (props: OutcomeCardProps) => {
         {true && (
           <Body>
             <MainValue>
-              <Label>
+              <Label $active={active}>
                 {isForecast
                   ? t('table-scenario-forecast')
                   : t('table-historical')}{' '}

--- a/src/components/general/OutcomeCardSet.tsx
+++ b/src/components/general/OutcomeCardSet.tsx
@@ -18,7 +18,7 @@ const CardSet = styled(animated.div)<{
   position: relative;
   padding-bottom: ${(props) => (props.$haschildren ? '190px' : '1rem')};
   margin-top: 1rem;
-  background-color: ${(props) => props.theme.graphColors.grey005};
+  background-color: ${({ theme }) => theme.cardBackground.secondary};
   // border-radius:  ${(props) => props.theme.cardBorderRadius};
   // border: 2px solid ${(props) =>
     props.$color || props.theme.themeColors.white};

--- a/src/components/general/WatchActionCard.tsx
+++ b/src/components/general/WatchActionCard.tsx
@@ -13,7 +13,7 @@ const ActionCard = styled.div`
 const ActionCardImage = styled.div`
   flex: 0 0 150px;
   position: relative;
-  background-color: ${(props) => props.theme.graphColors.grey005};
+  background-color: ${({ theme }) => theme.cardBackground.secondary};
 
   img {
     position: absolute;

--- a/src/pages/node/[slug].tsx
+++ b/src/pages/node/[slug].tsx
@@ -58,7 +58,7 @@ const NodeBodyText = styled.div`
 const ContentWrapper = styled.div`
   padding: 1.5rem;
   margin: 0.5rem 0;
-  background-color: ${(props) => props.theme.graphColors.grey005};
+  background-color: ${({ theme }) => theme.cardBackground.secondary};
   border-radius: ${(props) => props.theme.cardBorderRadius};
 
   .x2sstick text,


### PR DESCRIPTION
Depends on https://github.com/kausaltech/kausal-themes/pull/4

This fixes Zürich's accessibility colour contrast issues and works towards using the `cardBackground` and `textColor` abstractions for consistency across components.