### PR TITLE
Support hiding non-municipality actions

### DIFF
--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -1863,6 +1863,7 @@ export type GetPageQuery = {
   page?:
     | ({
         showOnlyMunicipalActions?: boolean | null;
+        defaultSortOrder: ActionSortOrder;
         id?: string | null;
         title: string;
         actionListLeadTitle?: string | null;

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -74,7 +74,7 @@ export type PlaywrightGetInstanceInfoQuery = {
   } & { __typename?: 'InstanceType' };
   pages: Array<
     { urlPath: string; title: string; showInMenus: boolean } & {
-      __typename?:
+      __typename:
         | 'ActionListPage'
         | 'InstanceRootPage'
         | 'OutcomePage'
@@ -1862,6 +1862,7 @@ export type GetPageQuery = {
     | null;
   page?:
     | ({
+        showOnlyMunicipalActions?: boolean | null;
         id?: string | null;
         title: string;
         actionListLeadTitle?: string | null;

--- a/src/queries/getPage.js
+++ b/src/queries/getPage.js
@@ -105,6 +105,7 @@ const GET_PAGE = gql`
       ... on ActionListPage {
         actionListLeadTitle: leadTitle
         actionListLeadParagraph: leadParagraph
+        showOnlyMunicipalActions
       }
       ... on StaticPage {
         body {

--- a/src/queries/getPage.js
+++ b/src/queries/getPage.js
@@ -106,6 +106,7 @@ const GET_PAGE = gql`
         actionListLeadTitle: leadTitle
         actionListLeadParagraph: leadParagraph
         showOnlyMunicipalActions
+        defaultSortOrder
       }
       ... on StaticPage {
         body {


### PR DESCRIPTION
- Filter out actions if they're decided at a national level and `showOnlyMunicipalActions` is selected in the CMS
- Only display action groups that belong to an action in the filter dropdown