### PR TITLE
Support default sort selection and fix impact sorting

### DIFF
--- a/src/components/common/ScenarioBadge.tsx
+++ b/src/components/common/ScenarioBadge.tsx
@@ -73,6 +73,7 @@ ScenarioBadge.propTypes = {
   children: PropTypes.node,
   size: PropTypes.string,
   color: PropTypes.string,
+  type: PropTypes.string,
   isLink: PropTypes.bool,
 };
 

--- a/src/components/general/ActionListCard.tsx
+++ b/src/components/general/ActionListCard.tsx
@@ -115,10 +115,6 @@ const ActionListCard = (props: ActionListCardProps) => {
 
   // const unitYearly = `kt CO<sub>2</sub>e${t('abbr-per-annum')}`;
   const unitYearly = `${action.impactMetric.unit?.htmlShort}`;
-  const actionEffectYearly =
-    action.impactMetric.forecastValues.find(
-      (dataPoint) => dataPoint.year === displayYears[1]
-    )?.value || 0;
 
   //const actionEffectCumulative = action.impactMetric.cumulativeForecastValue;
   const actionEffectCumulative = summarizeYearlyValuesBetween(
@@ -185,7 +181,7 @@ const ActionListCard = (props: ActionListCardProps) => {
           {action.impactMetric && !hasEfficiency && (
             <ImpactDisplay
               effectCumulative={actionEffectCumulative}
-              effectYearly={actionEffectYearly}
+              effectYearly={action.impactOnTargetYear}
               yearRange={displayYears}
               unitCumulative={unitCumulative}
               unitYearly={unitYearly}

--- a/src/components/general/ActionsComparison.tsx
+++ b/src/components/general/ActionsComparison.tsx
@@ -1,11 +1,7 @@
 import styled from 'styled-components';
+import { SortActionsConfig } from 'types/actions.types';
 import ActionComparisonGraph from 'components/graphs/ActionComparisonGraph';
 import { Spinner } from 'reactstrap';
-
-const ActionCount = styled.div`
-  margin: 0 0 ${({ theme }) => theme.spaces.s100};
-  color: ${({ theme }) => theme.themeColors.white};
-`;
 
 const LoadingOverlay = styled.div`
   position: absolute;
@@ -29,15 +25,27 @@ const GraphCard = styled.div`
   box-shadow: 3px 3px 12px rgba(33, 33, 33, 0.15);
 `;
 
+type Props = {
+  sortBy?: SortActionsConfig['sortKey'];
+
+  // TODO: Type props
+  actions;
+  id;
+  actionGroups;
+  sortAscending;
+  refetching;
+  displayYears;
+};
+
 const ActionsComparison = ({
   actions,
   id,
   actionGroups,
-  sortBy,
+  sortBy = 'cumulativeImpact',
   sortAscending,
   refetching,
   displayYears,
-}) => {
+}: Props) => {
   // if we have efficiency limit set, remove actions over that limit
 
   const actionsWithImpact = actions.map((action) => {
@@ -51,8 +59,8 @@ const ActionsComparison = ({
   });
 
   const sortActions = (a, b) => {
-    let aValue = a[sortBy];
-    let bValue = b[sortBy];
+    const aValue = a[sortBy];
+    const bValue = b[sortBy];
 
     return sortAscending ? aValue - bValue : bValue - aValue;
   };

--- a/src/components/general/ActionsList.tsx
+++ b/src/components/general/ActionsList.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import { Row, Col } from 'reactstrap';
-import { summarizeYearlyValuesBetween } from 'common/preprocess';
 import ActionListCard from 'components/general/ActionListCard';
 import { ActionWithEfficiency, SortActionsConfig } from 'types/actions.types';
 import { useMemo } from 'react';
@@ -29,15 +28,10 @@ const ActionListCategory = styled.div`
 
 const getValueForSorting = (
   action: ActionWithEfficiency,
-  sortBy: SortActionsConfig,
-  yearRange: [number, number]
+  sortBy: SortActionsConfig
 ): number => {
   if (sortBy.key === 'CUM_IMPACT') {
-    return summarizeYearlyValuesBetween(
-      action.impactMetric,
-      yearRange[0],
-      yearRange[1]
-    );
+    return action.impactMetric?.cumulativeForecastValue ?? 0;
   }
 
   if (sortBy.sortKey) {
@@ -78,8 +72,8 @@ const ActionsList = ({
       return sortAscending ? 0 : -1;
     }
 
-    const aValue = getValueForSorting(a, sortBy, yearRange);
-    const bValue = getValueForSorting(b, sortBy, yearRange);
+    const aValue = getValueForSorting(a, sortBy);
+    const bValue = getValueForSorting(b, sortBy);
 
     return sortAscending ? aValue - bValue : bValue - aValue;
   };

--- a/src/components/general/ActionsList.tsx
+++ b/src/components/general/ActionsList.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { Row, Col } from 'reactstrap';
 import ActionListCard from 'components/general/ActionListCard';
-import { ActionWithEfficiency } from 'components/pages/ActionListPage';
+import { ActionWithEfficiency, SortActionsConfig } from 'types/actions.types';
 import { useMemo } from 'react';
 
 const ActionListList = styled(Row)`
@@ -26,12 +26,31 @@ const ActionListCategory = styled.div`
   }
 `;
 
+const getValueForSorting = (
+  action: ActionWithEfficiency,
+  sortBy: SortActionsConfig
+): number => {
+  if (sortBy.key === 'CUM_IMPACT') {
+    return action.impactMetric?.cumulativeForecastValue ?? 0;
+  }
+
+  if (sortBy.sortKey) {
+    const sortValue = action[sortBy.sortKey];
+
+    if (typeof sortValue === 'number') {
+      return sortValue;
+    }
+  }
+
+  return 0;
+};
+
 type ActionsListProps = {
   id?: string;
   actions: ActionWithEfficiency[];
   displayType: 'displayTypeYearly';
   yearRange: [number, number];
-  sortBy: string;
+  sortBy: SortActionsConfig;
   sortAscending: boolean;
   refetching: boolean;
 };
@@ -49,14 +68,13 @@ const ActionsList = ({
 
   //console.log("action list", actions);
   const sortActions = (a, b) => {
-    if (sortBy === 'default') return sortAscending ? 0 : -1;
-    // check if we are using efficiency
-    const aValue = a[sortBy]
-      ? a[sortBy]
-      : a.impactMetric?.cumulativeForecastValue;
-    const bValue = b[sortBy]
-      ? b[sortBy]
-      : b.impactMetric?.cumulativeForecastValue;
+    if (sortBy.key === 'STANDARD') {
+      return sortAscending ? 0 : -1;
+    }
+
+    const aValue = getValueForSorting(a, sortBy);
+    const bValue = getValueForSorting(b, sortBy);
+
     return sortAscending ? aValue - bValue : bValue - aValue;
   };
 
@@ -73,7 +91,6 @@ const ActionsList = ({
     return [...groups];
   }, [actions]);
 
-  // console.log("action groups", actionGroups);
   return (
     <div id={id}>
       {actionGroups?.map((group) => (

--- a/src/components/general/ActionsList.tsx
+++ b/src/components/general/ActionsList.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Row, Col } from 'reactstrap';
+import { summarizeYearlyValuesBetween } from 'common/preprocess';
 import ActionListCard from 'components/general/ActionListCard';
 import { ActionWithEfficiency, SortActionsConfig } from 'types/actions.types';
 import { useMemo } from 'react';
@@ -28,10 +29,15 @@ const ActionListCategory = styled.div`
 
 const getValueForSorting = (
   action: ActionWithEfficiency,
-  sortBy: SortActionsConfig
+  sortBy: SortActionsConfig,
+  yearRange: [number, number]
 ): number => {
   if (sortBy.key === 'CUM_IMPACT') {
-    return action.impactMetric?.cumulativeForecastValue ?? 0;
+    return summarizeYearlyValuesBetween(
+      action.impactMetric,
+      yearRange[0],
+      yearRange[1]
+    );
   }
 
   if (sortBy.sortKey) {
@@ -72,8 +78,8 @@ const ActionsList = ({
       return sortAscending ? 0 : -1;
     }
 
-    const aValue = getValueForSorting(a, sortBy);
-    const bValue = getValueForSorting(b, sortBy);
+    const aValue = getValueForSorting(a, sortBy, yearRange);
+    const bValue = getValueForSorting(b, sortBy, yearRange);
 
     return sortAscending ? aValue - bValue : bValue - aValue;
   };

--- a/src/types/actions.types.ts
+++ b/src/types/actions.types.ts
@@ -1,0 +1,31 @@
+import {
+  ActionSortOrder,
+  GetActionListQuery,
+} from 'common/__generated__/graphql';
+
+export type ActionWithEfficiency = GetActionListQuery['actions'][0] & {
+  impactOnTargetYear: number;
+  cumulativeImpact?: number;
+  cumulativeImpactUnit?: string;
+  cumulativeImpactName?: string;
+  efficiencyDivisor?: number;
+  cumulativeEfficiency?: number;
+  cumulativeEfficiencyUnit?: string;
+  cumulativeEfficiencyName?: string;
+  cumulativeCost?: number;
+  cumulativeCostUnit?: string;
+  cumulativeCostName?: string;
+  efficiencyCap?: number;
+};
+
+export type SortActionsBy =
+  | `${ActionSortOrder}`
+  | 'CUM_EFFICIENCY'
+  | 'CUM_COST';
+
+export type SortActionsConfig = {
+  key: SortActionsBy;
+  label: string;
+  isHidden?: boolean;
+  sortKey?: NonNullable<keyof ActionWithEfficiency>;
+};


### PR DESCRIPTION
- Preselect the action sort field based on selected default sort in the admin UI
- Fix broken impact sorting – previously, impact was always sorted by cumulative impact
- Hide the cumulative impact sorting option if `instance.features.showAccumulatedEffects` is false