### PR TITLE
Changed logo width for desktop

### DIFF
--- a/src/components/custom/zurich/GlobalNav.tsx
+++ b/src/components/custom/zurich/GlobalNav.tsx
@@ -81,6 +81,15 @@ const HomeLink = styled.a`
 
   @media (min-width: ${(props) => props.theme.breakpointMd}) {
     svg {
+      width: 180px;
+      margin: ${(props) => props.theme.spaces.s050}
+        ${(props) => props.theme.spaces.s150}
+        ${(props) => props.theme.spaces.s050} 0;
+    }
+  }
+
+  @media (min-width: ${(props) => props.theme.breakpointXl}) {
+    svg {
       width: 242px;
       margin: ${(props) => props.theme.spaces.s050}
         ${(props) => props.theme.spaces.s150}

--- a/src/components/custom/zurich/GlobalNav.tsx
+++ b/src/components/custom/zurich/GlobalNav.tsx
@@ -81,7 +81,7 @@ const HomeLink = styled.a`
 
   @media (min-width: ${(props) => props.theme.breakpointMd}) {
     svg {
-      width: 180px;
+      width: 242px;
       margin: ${(props) => props.theme.spaces.s050}
         ${(props) => props.theme.spaces.s150}
         ${(props) => props.theme.spaces.s050} 0;

--- a/src/components/custom/zurich/GlobalNav.tsx
+++ b/src/components/custom/zurich/GlobalNav.tsx
@@ -82,18 +82,12 @@ const HomeLink = styled.a`
   @media (min-width: ${(props) => props.theme.breakpointMd}) {
     svg {
       width: 180px;
-      margin: ${(props) => props.theme.spaces.s050}
-        ${(props) => props.theme.spaces.s150}
-        ${(props) => props.theme.spaces.s050} 0;
     }
   }
 
   @media (min-width: ${(props) => props.theme.breakpointXl}) {
     svg {
       width: 242px;
-      margin: ${(props) => props.theme.spaces.s050}
-        ${(props) => props.theme.spaces.s150}
-        ${(props) => props.theme.spaces.s050} 0;
     }
   }
 `;


### PR DESCRIPTION
Changed logo width according to Zürich's site header reference (from 180 to 242 px) for desktop.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205795801398755