### PR TITLE
Restyle scenario badges

### DIFF
--- a/src/components/common/ScenarioBadge.tsx
+++ b/src/components/common/ScenarioBadge.tsx
@@ -1,80 +1,45 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import styled, { useTheme } from 'styled-components';
+import styled from 'styled-components';
 
-const StyledBadge = styled.div<{ $color: string; $isLink?: boolean }>`
+const StyledBadge = styled.div`
   display: inline-block;
   max-width: 100%;
   padding: 0.25rem 0.5rem;
   margin-bottom: 0.5rem;
   background-color: white !important;
-  // border-left: 24px solid ${(props) => props.$color} !important;
-  color: ${(props) => props.theme.themeColors.black};
-  border-radius: ${(props) => props.theme.badgeBorderRadius};
-  font-weight: ${(props) => props.theme.badgeFontWeight};
+  font-size: ${(props) => props.theme.fontSizeSm};
+  color: ${(props) => props.theme.graphColors.grey070};
   word-break: break-all;
   word-break: break-word;
   hyphens: manual;
   white-space: normal;
   text-align: left;
-
-  &:hover {
-    background-color: ${(props) =>
-      props.$isLink && darken(0.05, props.theme[props.$color])} !important;
-  }
-
-  &.lg {
-    font-size: ${(props) => props.theme.fontSizeMd};
-  }
-  &.md {
-    font-size: ${(props) => props.theme.fontSizeBase};
-  }
-  &.sm {
-    font-size: ${(props) => props.theme.fontSizeSm};
-  }
 `;
 
-const getBadgeColor = (theme, type, color) => {
-  switch (type) {
-    case 'forecast':
-      return theme.graphColors.grey060;
-    case 'activeScenario':
-      return theme.graphColors.grey030;
-    case 'scenario':
-      return theme.graphColors.grey020;
-    default:
-      return theme[color];
-  }
+const BadgeYears = styled.span`
+  font-weight: ${(props) => props.theme.fontWeightBold};
+  color: ${(props) => props.theme.themeColors.black};
+  margin-bottom: 0.5rem;
+`;
+
+type ScenarioBadgeProps = {
+  children?: React.ReactNode;
+  type?: string;
+  startYear?: number;
+  endYear?: number;
 };
 
-const ScenarioBadge = (props) => {
-  const { children, size, color, isLink, type } = props;
-  const theme = useTheme();
+const ScenarioBadge = (props: ScenarioBadgeProps) => {
+  const { children, startYear, endYear } = props;
 
   return (
-    <StyledBadge
-      className={size}
-      $color={getBadgeColor(theme, type, color)}
-      $isLink={isLink}
-    >
+    <StyledBadge>
+      {startYear && endYear && (
+        <BadgeYears>{`${startYear} - ${endYear}`}: </BadgeYears>
+      )}
       {children}
     </StyledBadge>
   );
-};
-
-ScenarioBadge.defaultProps = {
-  children: null,
-  size: 'sm',
-  color: 'brandDark',
-  isLink: false,
-};
-
-ScenarioBadge.propTypes = {
-  children: PropTypes.node,
-  size: PropTypes.string,
-  color: PropTypes.string,
-  type: PropTypes.string,
-  isLink: PropTypes.bool,
 };
 
 export default ScenarioBadge;

--- a/src/components/general/OutcomeNodeContent.tsx
+++ b/src/components/general/OutcomeNodeContent.tsx
@@ -87,9 +87,9 @@ const CardSetHeader = styled.div`
 `;
 
 const CardSetDescription = styled.div`
-  margin-bottom: 1rem;
+  margin-bottom: ${({ theme }) => theme.spaces.s100};
   h4 {
-    margin-bottom: 1rem;
+    margin-bottom: ${({ theme }) => theme.spaces.s050};
   }
 `;
 
@@ -178,15 +178,18 @@ const OutcomeNodeContent = ({
             </h4>
             <CardSetDescriptionDetails>
               {startYear < lastMeasuredYear && (
-                <ScenarioBadge type="forecast">
-                  {startYear}—{lastMeasuredYear} {t('table-historical')}
+                <ScenarioBadge startYear={startYear} endYear={lastMeasuredYear}>
+                  {t('table-historical')}
                 </ScenarioBadge>
               )}{' '}
               {typeof firstForecastYear === 'number' &&
                 firstForecastYear < endYear && (
-                  <ScenarioBadge type="activeScenario">
-                    {Math.max(startYear, firstForecastYear)}—{endYear}{' '}
-                    {t('table-scenario-forecast')} {activeScenario || 'Current'}
+                  <ScenarioBadge
+                    startYear={Math.max(startYear, firstForecastYear)}
+                    endYear={endYear}
+                  >
+                    {t('table-scenario-forecast')}
+                    {activeScenario && ` (${activeScenario})`}
                   </ScenarioBadge>
                 )}
             </CardSetDescriptionDetails>

--- a/src/components/pages/ActionListPage.tsx
+++ b/src/components/pages/ActionListPage.tsx
@@ -453,7 +453,7 @@ function ActionListPage({ page }: ActionListPageProps) {
             </Row>
           </SettingsForm>
           <ActionCount>
-            <ScenarioBadge type="activeScenario">
+            <ScenarioBadge>
               {t('scenario')}: {activeScenario?.name}
             </ScenarioBadge>
             <div>{t('actions-count', { count: usableActions.length })}</div>


### PR DESCRIPTION
BEFORE
![Screenshot 2023-10-27 at 14 45 32](https://github.com/kausaltech/kausal-paths-ui/assets/664877/89a51213-472d-4fbe-9d1f-6bc152f68597)

AFTER
![Screenshot 2023-10-27 at 14 45 21](https://github.com/kausaltech/kausal-paths-ui/assets/664877/06d864f3-2ba1-4d4c-8887-e871be5a4ced)

Still keeping these chippy. Just removing the rounding and adding some styling inside

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205795801398769