### PR TITLE
Fix fill styles for join between historical and forecast datasets

### DIFF
--- a/src/components/general/DimensionalNodePlot.tsx
+++ b/src/components/general/DimensionalNodePlot.tsx
@@ -220,6 +220,7 @@ export default function DimensionalNodePlot({
 
   let colors: string[];
   const nrCats = slice.categoryValues.length;
+
   if (nrCats > 1) {
     // If we were asked to use a specific color, we generate the color scheme around it.
     if (color) {
@@ -293,7 +294,6 @@ export default function DimensionalNodePlot({
         y: [cv.historicalValues[lastHist], cv.forecastValues[0]],
         hoverinfo: 'skip',
         showlegend: false,
-        fillcolor: tint(0.3, color),
       });
     }
     if (hasForecast) {


### PR DESCRIPTION
Forecast fill styles should be used _after_ the first forecast year.