### PR TITLE
Show action goal on cards, action page and in subactions

### DIFF
--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -15,6 +15,7 @@ export type Scalars = {
   DateTime: { input: any; output: any; }
   JSONString: { input: any; output: any; }
   PositiveInt: { input: any; output: any; }
+  RichText: { input: any; output: any; }
   UUID: { input: any; output: any; }
 };
 
@@ -352,7 +353,7 @@ export type GetNodePageQueryVariables = Exact<{
 
 export type GetNodePageQuery = (
   { node: (
-    { id: string, name: string, shortDescription: string | null, description: string | null, color: string | null, targetYearGoal: number | null, quantity: string | null, isAction: boolean, unit: (
+    { id: string, name: string, shortDescription: any | null, description: string | null, color: string | null, targetYearGoal: number | null, quantity: string | null, isAction: boolean, unit: (
       { htmlShort: string }
       & { __typename: 'UnitType' }
     ) | null, metric: (
@@ -371,13 +372,13 @@ export type GetNodePageQuery = (
       )> | null }
       & { __typename: 'ForecastMetricType' }
     ) | null, inputNodes: Array<(
-      { id: string, name: string, shortDescription: string | null, color: string | null, quantity: string | null, isAction: boolean, unit: (
+      { id: string, name: string, shortDescription: any | null, color: string | null, quantity: string | null, isAction: boolean, unit: (
         { htmlShort: string }
         & { __typename: 'UnitType' }
       ) | null }
       & { __typename: 'ActionNode' | 'Node' }
     )>, outputNodes: Array<(
-      { id: string, name: string, shortDescription: string | null, color: string | null, quantity: string | null, isAction: boolean, unit: (
+      { id: string, name: string, shortDescription: any | null, color: string | null, quantity: string | null, isAction: boolean, unit: (
         { htmlShort: string }
         & { __typename: 'UnitType' }
       ) | null }
@@ -449,7 +450,7 @@ export type GetActionContentQueryVariables = Exact<{
 
 export type GetActionContentQuery = (
   { action: (
-    { description: string | null, decisionLevel: DecisionLevel | null, id: string, name: string, shortDescription: string | null, color: string | null, targetYearGoal: number | null, quantity: string | null, dimensionalFlow: (
+    { goal: any | null, description: string | null, decisionLevel: DecisionLevel | null, id: string, name: string, shortDescription: any | null, color: string | null, targetYearGoal: number | null, quantity: string | null, dimensionalFlow: (
       { id: string, sources: Array<string>, unit: (
         { htmlLong: string }
         & { __typename: 'UnitType' }
@@ -462,7 +463,7 @@ export type GetActionContentQuery = (
       )> }
       & { __typename: 'DimensionalFlowType' }
     ) | null, downstreamNodes: Array<(
-      { id: string, name: string, shortDescription: string | null, color: string | null, targetYearGoal: number | null, quantity: string | null, group: (
+      { id: string, name: string, shortDescription: any | null, color: string | null, targetYearGoal: number | null, quantity: string | null, group: (
         { id: string, name: string, color: string | null }
         & { __typename: 'ActionGroupType' }
       ) | null, unit: (
@@ -561,7 +562,7 @@ export type GetActionContentQuery = (
       ) | null }
       & { __typename: 'ActionNode' }
     ) | (
-      { id: string, name: string, shortDescription: string | null, color: string | null, targetYearGoal: number | null, quantity: string | null, unit: (
+      { id: string, name: string, shortDescription: any | null, color: string | null, targetYearGoal: number | null, quantity: string | null, unit: (
         { htmlShort: string }
         & { __typename: 'UnitType' }
       ) | null, inputNodes: Array<(
@@ -657,11 +658,11 @@ export type GetActionContentQuery = (
       ) | null }
       & { __typename: 'Node' }
     )>, subactions: Array<(
-      { id: string, name: string, description: string | null, shortDescription: string | null, isEnabled: boolean, parameters: Array<(
+      { id: string, name: string, description: string | null, goal: any | null, shortDescription: any | null, isEnabled: boolean, parameters: Array<(
         { id: string }
         & { __typename: 'BoolParameterType' | 'NumberParameterType' | 'StringParameterType' | 'UnknownParameterType' }
       )>, downstreamNodes: Array<(
-        { id: string, name: string, shortDescription: string | null, color: string | null, targetYearGoal: number | null, quantity: string | null, group: (
+        { id: string, name: string, shortDescription: any | null, color: string | null, targetYearGoal: number | null, quantity: string | null, group: (
           { id: string, name: string, color: string | null }
           & { __typename: 'ActionGroupType' }
         ) | null, unit: (
@@ -760,7 +761,7 @@ export type GetActionContentQuery = (
         ) | null }
         & { __typename: 'ActionNode' }
       ) | (
-        { id: string, name: string, shortDescription: string | null, color: string | null, targetYearGoal: number | null, quantity: string | null, unit: (
+        { id: string, name: string, shortDescription: any | null, color: string | null, targetYearGoal: number | null, quantity: string | null, unit: (
           { htmlShort: string }
           & { __typename: 'UnitType' }
         ) | null, inputNodes: Array<(
@@ -960,7 +961,7 @@ export type GetActionContentQuery = (
 );
 
 type CausalGridNode_ActionNode_Fragment = (
-  { id: string, name: string, shortDescription: string | null, color: string | null, targetYearGoal: number | null, quantity: string | null, group: (
+  { id: string, name: string, shortDescription: any | null, color: string | null, targetYearGoal: number | null, quantity: string | null, group: (
     { id: string, name: string, color: string | null }
     & { __typename: 'ActionGroupType' }
   ) | null, unit: (
@@ -1061,7 +1062,7 @@ type CausalGridNode_ActionNode_Fragment = (
 );
 
 type CausalGridNode_Node_Fragment = (
-  { id: string, name: string, shortDescription: string | null, color: string | null, targetYearGoal: number | null, quantity: string | null, unit: (
+  { id: string, name: string, shortDescription: any | null, color: string | null, targetYearGoal: number | null, quantity: string | null, unit: (
     { htmlShort: string }
     & { __typename: 'UnitType' }
   ) | null, inputNodes: Array<(
@@ -1220,7 +1221,7 @@ export type GetActionListQuery = (
     )> }
     & { __typename: 'InstanceType' }
   ), actions: Array<(
-    { id: string, name: string, shortDescription: string | null, color: string | null, decisionLevel: DecisionLevel | null, quantity: string | null, unit: (
+    { id: string, name: string, goal: any | null, shortDescription: any | null, color: string | null, decisionLevel: DecisionLevel | null, quantity: string | null, unit: (
       { htmlShort: string }
       & { __typename: 'UnitType' }
     ) | null, parameters: Array<(
@@ -1287,13 +1288,13 @@ export type GetActionListQuery = (
       { htmlShort: string }
       & { __typename: 'UnitType' }
     ), costNode: (
-      { id: string, name: string, shortDescription: string | null, unit: (
+      { id: string, name: string, shortDescription: any | null, unit: (
         { short: string }
         & { __typename: 'UnitType' }
       ) | null }
       & { __typename: 'Node' }
     ), impactNode: (
-      { id: string, name: string, shortDescription: string | null, unit: (
+      { id: string, name: string, shortDescription: any | null, unit: (
         { short: string }
         & { __typename: 'UnitType' }
       ) | null }
@@ -1320,7 +1321,7 @@ export type GetActionListQuery = (
 );
 
 export type OutcomeNodeFieldsFragment = (
-  { id: string, name: string, color: string | null, order: number | null, shortName: string | null, shortDescription: string | null, targetYearGoal: number | null, quantity: string | null, metric: (
+  { id: string, name: string, color: string | null, order: number | null, shortName: string | null, shortDescription: any | null, targetYearGoal: number | null, quantity: string | null, metric: (
     { id: string | null, name: string | null, unit: (
       { short: string, htmlShort: string, htmlLong: string }
       & { __typename: 'UnitType' }
@@ -1348,7 +1349,7 @@ export type OutcomeNodeFieldsFragment = (
     { id: string }
     & { __typename: 'ActionNode' | 'Node' }
   )>, upstreamActions: Array<(
-    { id: string, name: string, shortName: string | null, shortDescription: string | null, parameters: Array<(
+    { id: string, name: string, goal: any | null, shortName: string | null, shortDescription: any | null, parameters: Array<(
       { id: string, nodeRelativeId: string | null, isCustomized: boolean, boolValue: boolean | null, boolDefaultValue: boolean | null, node: (
         { id: string }
         & { __typename: 'ActionNode' | 'Node' }
@@ -1411,8 +1412,8 @@ export type GetPageQuery = (
     & { __typename: 'InstanceRootPage' | 'Page' }
   ) | (
     { leadTitle: string, leadParagraph: string, id: string | null, title: string, outcomeNode: (
-      { id: string, name: string, color: string | null, order: number | null, shortName: string | null, shortDescription: string | null, targetYearGoal: number | null, quantity: string | null, upstreamNodes: Array<{ __typename: 'ActionNode' } | (
-        { id: string, name: string, color: string | null, order: number | null, shortName: string | null, shortDescription: string | null, targetYearGoal: number | null, quantity: string | null, metric: (
+      { id: string, name: string, color: string | null, order: number | null, shortName: string | null, shortDescription: any | null, targetYearGoal: number | null, quantity: string | null, upstreamNodes: Array<{ __typename: 'ActionNode' } | (
+        { id: string, name: string, color: string | null, order: number | null, shortName: string | null, shortDescription: any | null, targetYearGoal: number | null, quantity: string | null, metric: (
           { id: string | null, name: string | null, unit: (
             { short: string, htmlShort: string, htmlLong: string }
             & { __typename: 'UnitType' }
@@ -1440,7 +1441,7 @@ export type GetPageQuery = (
           { id: string }
           & { __typename: 'ActionNode' | 'Node' }
         )>, upstreamActions: Array<(
-          { id: string, name: string, shortName: string | null, shortDescription: string | null, parameters: Array<(
+          { id: string, name: string, goal: any | null, shortName: string | null, shortDescription: any | null, parameters: Array<(
             { id: string, nodeRelativeId: string | null, isCustomized: boolean, boolValue: boolean | null, boolDefaultValue: boolean | null, node: (
               { id: string }
               & { __typename: 'ActionNode' | 'Node' }
@@ -1511,7 +1512,7 @@ export type GetPageQuery = (
         { id: string }
         & { __typename: 'ActionNode' | 'Node' }
       )>, upstreamActions: Array<(
-        { id: string, name: string, shortName: string | null, shortDescription: string | null, parameters: Array<(
+        { id: string, name: string, goal: any | null, shortName: string | null, shortDescription: any | null, parameters: Array<(
           { id: string, nodeRelativeId: string | null, isCustomized: boolean, boolValue: boolean | null, boolDefaultValue: boolean | null, node: (
             { id: string }
             & { __typename: 'ActionNode' | 'Node' }
@@ -1559,10 +1560,10 @@ export type GetPageQuery = (
   ) | (
     { id: string | null, title: string, body: Array<(
       { id: string | null }
-      & { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CharBlock' | 'ChoiceBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'FloatBlock' | 'ImageChooserBlock' | 'IntegerBlock' | 'ListBlock' | 'PageChooserBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'StaticBlock' | 'StreamBlock' | 'StreamFieldBlock' }
+      & { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardListBlock' | 'CharBlock' | 'ChoiceBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'FloatBlock' | 'ImageChooserBlock' | 'IntegerBlock' | 'ListBlock' | 'PageChooserBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'StaticBlock' | 'StreamBlock' }
     ) | (
       { id: string | null }
-      & { __typename: 'StructBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' }
+      & { __typename: 'StreamFieldBlock' | 'StructBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' }
     ) | (
       { value: string, rawValue: string, id: string | null }
       & { __typename: 'RichTextBlock' }

--- a/src/common/__generated__/possible_types.json
+++ b/src/common/__generated__/possible_types.json
@@ -20,6 +20,7 @@
     "StreamFieldInterface": [
       "BlockQuoteBlock",
       "BooleanBlock",
+      "CardListBlock",
       "CharBlock",
       "ChoiceBlock",
       "DateBlock",

--- a/src/components/general/ActionGoal.tsx
+++ b/src/components/general/ActionGoal.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+/**
+ * Added for Zürich, in future this will be renamed to be more generic and
+ * not clash with the concept of "goals" e.g. as a custom field.
+ */
+export const ActionGoal = styled.div`
+  max-width: ${({ theme }) => theme.breakpointSm};
+  background-color: ${({ theme }) => theme.graphColors.blue010};
+  border-radius: ${({ theme }) => theme.cardBorderRadius};
+  padding: ${({ theme }) => theme.spaces.s100};
+  margin-bottom: ${({ theme }) => theme.spaces.s200};
+
+  p:last-of-type {
+    margin-bottom: 0;
+  }
+`;

--- a/src/components/general/ActionListCard.tsx
+++ b/src/components/general/ActionListCard.tsx
@@ -119,15 +119,17 @@ const ActionListCard = (props: ActionListCardProps) => {
 
   const enabledParam = findActionEnabledParam(action.parameters);
   const isActive = !refetching && (enabledParam?.boolValue ?? false);
-
   const hasEfficiency = 'cumulativeEfficiency' in action;
 
-  /* Remove html formatting and clip description to max length */
-  const originalLength = action?.shortDescription?.length ?? 0;
   const removeHtml = /(<([^>]+)>)/gi;
-  let clippedDescription = action?.shortDescription
-    ? action.shortDescription.replace(removeHtml, '').slice(0, 120)
-    : '';
+
+  const description = (action?.goal || action?.shortDescription)?.replace(
+    removeHtml,
+    ''
+  );
+  const originalLength = description?.length ?? 0;
+  let clippedDescription = description ? description.slice(0, 220) : '';
+
   if (originalLength > clippedDescription.length) {
     clippedDescription += '...';
   }

--- a/src/components/general/SubActions.tsx
+++ b/src/components/general/SubActions.tsx
@@ -3,8 +3,14 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import WatchActionCard from './WatchActionCard';
-import { SubActionCardFragment } from 'common/__generated__/graphql';
+import {
+  GetActionContentQuery,
+  SubActionCardFragment,
+} from 'common/__generated__/graphql';
 import { useTranslation } from 'common/i18n';
+import { ActionGoal } from './ActionGoal';
+
+type SubAction = NonNullable<GetActionContentQuery['action']>['subactions'][0];
 
 const SubactionsHeader = styled.h2`
   font-size: ${({ theme }) => theme.fontSizeLg};
@@ -162,6 +168,9 @@ const ActionContent = (props: ActionContentProps) => {
       aria-labelledby={`action-tab-${action.id}`}
     >
       <ActionDescription>
+        {!!action.goal && (
+          <ActionGoal dangerouslySetInnerHTML={{ __html: action.goal }} />
+        )}
         {action.shortDescription || action.description ? (
           <div
             dangerouslySetInnerHTML={{
@@ -210,7 +219,8 @@ const SubActions = (props: SubActionsProps) => {
     <SubActionsContainer>
       <SubactionsHeader id="subactions">Ziele und Massnahmen</SubactionsHeader>
       <ActionTabs role="tablist" aria-labelledby="subactions">
-        {actions.map((action: any) =>
+        {actions.map((action: SubAction) =>
+          action.goal ||
           action.shortDescription ||
           action.description ||
           action.downstreamNodes.length > 0 ? (
@@ -230,7 +240,7 @@ const SubActions = (props: SubActionsProps) => {
               </TabTitle>
             </ActionTab>
           ) : (
-            <DisabledActionTab disabled>
+            <DisabledActionTab key={action.id} disabled>
               <TabTitle>
                 <div>{action.name}</div>
               </TabTitle>

--- a/src/pages/actions/[slug].tsx
+++ b/src/pages/actions/[slug].tsx
@@ -30,6 +30,7 @@ import ImpactDisplay from 'components/general/ImpactDisplay';
 import Icon from 'components/common/icon';
 import SubActions from 'components/general/SubActions';
 import Loader from 'components/common/Loader';
+import { ActionGoal } from 'components/general/ActionGoal';
 
 const HeaderSection = styled.div`
   padding: 3rem 0 1rem;
@@ -248,6 +249,13 @@ export default function ActionPage() {
               </div>
               <Row>
                 <Col xs={12} md={7} className="mb-4">
+                  {!!action.goal && (
+                    <ActionGoal
+                      dangerouslySetInnerHTML={{
+                        __html: action.goal,
+                      }}
+                    />
+                  )}
                   <ActionDescription>
                     <div
                       dangerouslySetInnerHTML={{

--- a/src/queries/getActionContent.js
+++ b/src/queries/getActionContent.js
@@ -8,6 +8,7 @@ const GET_ACTION_CONTENT = gql`
   query GetActionContent($node: ID!, $goal: ID) {
     action(id: $node) {
       ...CausalGridNode
+      goal
       description
       dimensionalFlow {
         ...DimensionalPlot
@@ -20,6 +21,7 @@ const GET_ACTION_CONTENT = gql`
         id
         name
         description
+        goal
         shortDescription
         isEnabled
         parameters {

--- a/src/queries/getActionList.js
+++ b/src/queries/getActionList.js
@@ -17,6 +17,7 @@ const GET_ACTION_LIST = gql`
     actions(onlyRoot: true) {
       id
       name
+      goal
       shortDescription
       color
       decisionLevel

--- a/src/queries/getPage.js
+++ b/src/queries/getPage.js
@@ -52,6 +52,7 @@ const OUTCOME_NODE_FIELDS = gql`
     upstreamActions(onlyRoot: true, decisionLevel: MUNICIPALITY) {
       id
       name
+      goal
       shortName
       shortDescription
       parameters {


### PR DESCRIPTION
Primarily for Zürich, this will likely be renamed later to be more generic i.e. as custom fields.

- Display action goal by default on action list page if given
- Display goal above action description on action page
- Display goal under subactions on action page

Note there's a backend bug where the `shortDescription` from the yaml file is returned if nothing is defined in wagtail, hence the random "-" in the second screenshot.

<img width="1373" alt="image" src="https://github.com/kausaltech/kausal-paths-ui/assets/15343658/659f9a60-80b2-42cf-bb81-cddad1b9bf06">
<img width="1367" alt="image" src="https://github.com/kausaltech/kausal-paths-ui/assets/15343658/09980c68-d54a-410e-ba18-ad8bda648894">
