### PR TITLE
Add Kausal Watch action card support

### DIFF
--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -86,6 +86,36 @@ export type AllMetricFieldsFragment = (
   & { __typename: 'ForecastMetricType' }
 );
 
+type StreamFieldFragment_ZQdWsvqmDgiXfDp7wkeLw2YTay53DiSfbOf2CGiE7U_Fragment = (
+  { id: string | null, blockType: string, field: string }
+  & { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CharBlock' | 'ChoiceBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'FloatBlock' | 'ImageChooserBlock' | 'IntegerBlock' | 'ListBlock' | 'PageChooserBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'StaticBlock' | 'StreamBlock' | 'StreamFieldBlock' }
+);
+
+type StreamFieldFragment_StructBlock_TimeBlock_UrlBlock_Fragment = (
+  { id: string | null, blockType: string, field: string }
+  & { __typename: 'StructBlock' | 'TimeBlock' | 'URLBlock' }
+);
+
+type StreamFieldFragment_CardListBlock_Fragment = (
+  { blockType: string, title: string | null, id: string | null, field: string, cards: Array<(
+    { title: string | null, shortDescription: string | null }
+    & { __typename: 'CardListCardBlock' }
+  ) | null> | null }
+  & { __typename: 'CardListBlock' }
+);
+
+type StreamFieldFragment_RichTextBlock_Fragment = (
+  { value: string, rawValue: string, id: string | null, blockType: string, field: string }
+  & { __typename: 'RichTextBlock' }
+);
+
+type StreamFieldFragment_TextBlock_Fragment = (
+  { value: string, id: string | null, blockType: string, field: string }
+  & { __typename: 'TextBlock' }
+);
+
+export type StreamFieldFragmentFragment = StreamFieldFragment_ZQdWsvqmDgiXfDp7wkeLw2YTay53DiSfbOf2CGiE7U_Fragment | StreamFieldFragment_StructBlock_TimeBlock_UrlBlock_Fragment | StreamFieldFragment_CardListBlock_Fragment | StreamFieldFragment_RichTextBlock_Fragment | StreamFieldFragment_TextBlock_Fragment;
+
 type ActionParameter_BoolParameterType_Fragment = (
   { id: string, label: string | null, description: string | null, nodeRelativeId: string | null, isCustomized: boolean, isCustomizable: boolean, boolValue: boolean | null, boolDefaultValue: boolean | null, node: (
     { id: string }
@@ -445,6 +475,7 @@ export type DimensionalNodeMetricFragment = (
 export type GetActionContentQueryVariables = Exact<{
   node: Scalars['ID']['input'];
   goal: InputMaybe<Scalars['ID']['input']>;
+  downstreamDepth: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 
@@ -856,7 +887,25 @@ export type GetActionContentQuery = (
           & { __typename: 'ForecastMetricType' }
         ) | null }
         & { __typename: 'Node' }
-      )> }
+      )>, body: Array<(
+        { id: string | null, blockType: string, field: string }
+        & { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CharBlock' | 'ChoiceBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'FloatBlock' | 'ImageChooserBlock' | 'IntegerBlock' | 'ListBlock' | 'PageChooserBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'StaticBlock' | 'StreamBlock' | 'StreamFieldBlock' }
+      ) | (
+        { id: string | null, blockType: string, field: string }
+        & { __typename: 'StructBlock' | 'TimeBlock' | 'URLBlock' }
+      ) | (
+        { blockType: string, title: string | null, id: string | null, field: string, cards: Array<(
+          { title: string | null, shortDescription: string | null }
+          & { __typename: 'CardListCardBlock' }
+        ) | null> | null }
+        & { __typename: 'CardListBlock' }
+      ) | (
+        { value: string, rawValue: string, id: string | null, blockType: string, field: string }
+        & { __typename: 'RichTextBlock' }
+      ) | (
+        { value: string, id: string | null, blockType: string, field: string }
+        & { __typename: 'TextBlock' }
+      )> | null }
       & { __typename: 'ActionNode' }
     )>, group: (
       { id: string, name: string, color: string | null }
@@ -1559,14 +1608,23 @@ export type GetPageQuery = (
     & { __typename: 'OutcomePage' }
   ) | (
     { id: string | null, title: string, body: Array<(
-      { id: string | null }
-      & { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardListBlock' | 'CharBlock' | 'ChoiceBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'FloatBlock' | 'ImageChooserBlock' | 'IntegerBlock' | 'ListBlock' | 'PageChooserBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'StaticBlock' | 'StreamBlock' }
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CharBlock' | 'ChoiceBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'FloatBlock' | 'ImageChooserBlock' | 'IntegerBlock' | 'ListBlock' | 'PageChooserBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'StaticBlock' | 'StreamBlock' | 'StreamFieldBlock' }
     ) | (
-      { id: string | null }
-      & { __typename: 'StreamFieldBlock' | 'StructBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' }
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'StructBlock' | 'TimeBlock' | 'URLBlock' }
     ) | (
-      { value: string, rawValue: string, id: string | null }
+      { blockType: string, title: string | null, id: string | null, field: string, cards: Array<(
+        { title: string | null, shortDescription: string | null }
+        & { __typename: 'CardListCardBlock' }
+      ) | null> | null }
+      & { __typename: 'CardListBlock' }
+    ) | (
+      { value: string, rawValue: string, id: string | null, blockType: string, field: string }
       & { __typename: 'RichTextBlock' }
+    ) | (
+      { value: string, id: string | null, blockType: string, field: string }
+      & { __typename: 'TextBlock' }
     ) | null> | null }
     & { __typename: 'StaticPage' }
   ) | null }

--- a/src/common/apollo.ts
+++ b/src/common/apollo.ts
@@ -158,6 +158,11 @@ function createApolloClient(opts: ApolloClientOpts) {
     ]),
     cache: new InMemoryCache({
       possibleTypes: possibleTypes.possibleTypes,
+      typePolicies: {
+        CardListCardBlock: {
+          keyFields: false,
+        },
+      },
     }),
   });
 }

--- a/src/components/common/CardListBlock.tsx
+++ b/src/components/common/CardListBlock.tsx
@@ -1,0 +1,47 @@
+import styled from 'styled-components';
+import { Card, CardText, CardTitle } from 'reactstrap';
+
+type Props = {
+  title?: string;
+  cards: {
+    title: string;
+    shortDescription?: string;
+  }[];
+};
+
+const StyledCardContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: ${({ theme }) => theme.spaces.s100};
+`;
+
+const StyledCard = styled(Card)`
+  border-radius: ${({ theme }) => theme.cardBorderRadius};
+  border: none;
+  background-color: ${({ theme }) => theme.cardBackground.secondary};
+  padding: ${({ theme }) => theme.spaces.s100};
+`;
+
+const StyledCardTitle = styled(CardTitle)`
+  line-height: ${({ theme }) => theme.lineHeightMd};
+  color: ${({ theme }) => theme.textColor.secondary};
+`;
+
+export function CardListBlock({ title, cards }: Props) {
+  return (
+    <>
+      {!!title && <h5>{title}</h5>}
+
+      <StyledCardContainer>
+        {cards.map((card, i) => (
+          <StyledCard key={i}>
+            <StyledCardTitle tag="p">{card.title}</StyledCardTitle>
+            {!!card.shortDescription && (
+              <CardText>{card.shortDescription}</CardText>
+            )}
+          </StyledCard>
+        ))}
+      </StyledCardContainer>
+    </>
+  );
+}

--- a/src/components/common/StreamField.tsx
+++ b/src/components/common/StreamField.tsx
@@ -1,0 +1,56 @@
+import { gql } from '@apollo/client';
+import RichText from './RichText';
+import { StreamFieldFragmentFragment } from 'common/__generated__/graphql';
+import { CardListBlock } from './CardListBlock';
+
+export const STREAM_FIELD_FRAGMENT = gql`
+  fragment StreamFieldFragment on StreamFieldInterface {
+    id
+    blockType
+    field
+
+    ... on RichTextBlock {
+      value
+      rawValue
+    }
+
+    ... on TextBlock {
+      value
+    }
+
+    ... on CardListBlock {
+      blockType
+      title
+      cards {
+        __typename
+        title
+        shortDescription
+      }
+    }
+  }
+`;
+
+type Props = {
+  block: StreamFieldFragmentFragment;
+};
+
+export function StreamField({ block }: Props) {
+  switch (block.__typename) {
+    case 'RichTextBlock':
+      return <RichText html={block.value} />;
+
+    case 'TextBlock':
+      return null;
+
+    case 'CardListBlock':
+      return (
+        <CardListBlock
+          cards={block.cards?.filter((card) => !!card?.title) ?? []}
+          title={block.title ?? undefined}
+        />
+      );
+
+    default:
+      return null;
+  }
+}

--- a/src/components/general/SubActions.tsx
+++ b/src/components/general/SubActions.tsx
@@ -2,13 +2,9 @@ import { useState } from 'react';
 
 import styled from 'styled-components';
 
-import WatchActionCard from './WatchActionCard';
-import {
-  GetActionContentQuery,
-  SubActionCardFragment,
-} from 'common/__generated__/graphql';
-import { useTranslation } from 'common/i18n';
+import { GetActionContentQuery } from 'common/__generated__/graphql';
 import { ActionGoal } from './ActionGoal';
+import { StreamField } from 'components/common/StreamField';
 
 type SubAction = NonNullable<GetActionContentQuery['action']>['subactions'][0];
 
@@ -97,69 +93,11 @@ const SubActionsContainer = styled.div`
   padding: ${({ theme }) => theme.spaces.s100};
 `;
 
-const WatchActionList = styled.div`
-  display: flex;
-  max-width: 100%;
-  flex-wrap: wrap;
-`;
-
 type ActionContentProps = {
-  action: SubActionCardFragment;
+  action: NonNullable<GetActionContentQuery['action']>['subactions'][0];
 };
 
-const TEMP_WATCH_ACTIONS = {
-  fossil_fuel_heater_to_district_heat: [
-    'Kommunale Energieplanung',
-    'Abstimmung zwischen Siedlungs- und Energieplanung',
-    'Ausbau der thermischen Netze',
-    'Ausbau 3. Verbrennungslinie KVA Hagenholz',
-    'Stilllegung Gasverteilnetz',
-    'Förderprogramm Heizungsersatz und Restwertentschädigung',
-    'Förderung erneuerbare Energien (Heizungsersatz)',
-    'Energieberatung',
-    'Informationsplattformen: EnerGIS und Energieplattform',
-    'Heizungsersatz bei städtischen Liegenschaften',
-  ],
-  district_heat_decarbonisation: [
-    'Dekarbonisierung der thermischen Netze',
-    'Ausbau 3. Verbrennungslinie KVA Hagenholz',
-    'Erneuerbares Gas',
-  ],
-  fossil_fuel_heater_to_heat_pumps: [
-    'Kommunale Energieplanung',
-    'Abstimmung zwischen Siedlungs- und Energieplanung',
-    'Förderprogramm Heizungsersatz und Restwertentschädigung',
-    'Förderung erneuerbare Energien (Heizungsersatz)',
-    'Energieberatung',
-    'Informationsplattformen: EnerGIS und Energieplattform',
-    'Heizungsersatz bei städtischen Liegenschaften',
-    'Stilllegung Gasverteilnetz',
-  ],
-  fossil_fuel_heater_to_other: [
-    'Kommunale Energieplanung',
-    'Abstimmung zwischen Siedlungs- und Energieplanung',
-    'Förderprogramm Heizungsersatz und Restwertentschädigung',
-    'Förderung erneuerbare Energien (Heizungsersatz)',
-    'Energieberatung',
-    'Informationsplattformen: EnerGIS und Energieplattform',
-    'Heizungsersatz bei städtischen Liegenschaften',
-    'Stilllegung Gasverteilnetz',
-  ],
-  natural_gas_network_decarbonisation: [
-    'Erneuerbares Gas',
-    'Stilllegung Gasverteilnetz',
-  ],
-  other_building_fuel_to_biogas: ['Erneuerbares Gas'],
-};
-
-const ActionContent = (props: ActionContentProps) => {
-  const { action } = props;
-  const { t } = useTranslation();
-
-  // Create test subsubaction data for one particular action
-  // TODO: Get this data from the API
-  const watchActions = TEMP_WATCH_ACTIONS[action.id] ?? [];
-
+const ActionContent = ({ action }: ActionContentProps) => {
   return (
     <ActionContentCard
       id={`action-content-${action.id}`}
@@ -179,30 +117,20 @@ const ActionContent = (props: ActionContentProps) => {
           />
         ) : null}
       </ActionDescription>
-      {watchActions.length > 0 && (
-        <>
-          <h5>{t('watch-action-list-title')}</h5>
-          <WatchActionList>
-            {watchActions.map((watchAction, i) => (
-              <WatchActionCard key={i} action={{ name: watchAction }} />
-            ))}
-            <WatchActionCard />
-            <WatchActionCard />
-          </WatchActionList>
-        </>
-      )}
+
+      {action.body?.map((block, i) => <StreamField key={i} block={block} />)}
     </ActionContentCard>
   );
 };
 
 type SubActionsProps = {
-  actions: SubActionCardFragment[];
+  actions: NonNullable<GetActionContentQuery['action']>['subactions'];
   activeSubAction?: string;
   setActiveSubAction: (subAction?: string) => void;
 };
 
 const SubActions = (props: SubActionsProps) => {
-  const { actions, activeSubAction, setActiveSubAction } = props;
+  const { actions, setActiveSubAction } = props;
   const [activeTab, setActiveTab] = useState('null');
 
   const handleClick = (id: string) => {

--- a/src/components/pages/StaticPage.tsx
+++ b/src/components/pages/StaticPage.tsx
@@ -2,8 +2,8 @@ import styled from 'styled-components';
 
 import type { GetPageQuery } from 'common/__generated__/graphql';
 import type { PageRefetchCallback } from './Page';
-import RichText from 'components/common/RichText';
 import { PageHero } from 'components/common/PageHero';
+import { StreamField } from 'components/common/StreamField';
 
 const BodyCard = styled.div`
   padding: 2rem;
@@ -23,12 +23,9 @@ function StaticPage({ page }: StaticPageProps) {
   return (
     <PageHero title={page.title} overlap>
       <BodyCard>
-        {(page?.body ?? []).map((block) => {
-          if (block?.__typename == 'RichTextBlock') {
-            return <RichText key={block.id} html={block.value} />;
-          }
-          return null;
-        })}
+        {page?.body?.map((block) =>
+          block ? <StreamField key={block.id} block={block} /> : null
+        )}
       </BodyCard>
     </PageHero>
   );

--- a/src/queries/getActionContent.js
+++ b/src/queries/getActionContent.js
@@ -3,6 +3,7 @@ import DimensionalFlow from 'components/graphs/DimensionalFlow';
 import { SUBACTIONS_FRAGMENT } from 'components/general/SubActions';
 import { ACTION_PARAMETER_FRAGMENT } from 'components/general/ActionParameters';
 import { DimensionalMetric } from 'data/metric';
+import { STREAM_FIELD_FRAGMENT } from 'components/common/StreamField';
 
 const GET_ACTION_CONTENT = gql`
   query GetActionContent($node: ID!, $goal: ID, $downstreamDepth: Int) {
@@ -24,16 +25,22 @@ const GET_ACTION_CONTENT = gql`
         goal
         shortDescription
         isEnabled
+        # isVisible
         parameters {
           id
         }
         downstreamNodes(maxDepth: 1) {
           ...CausalGridNode
         }
+        body {
+          ...StreamFieldFragment
+        }
       }
     }
   }
   ${DimensionalFlow.fragment}
+  ${STREAM_FIELD_FRAGMENT}
+
   fragment CausalGridNode on NodeInterface {
     id
     name

--- a/src/queries/getPage.js
+++ b/src/queries/getPage.js
@@ -1,5 +1,6 @@
 import { gql } from '@apollo/client';
 import dimensionalNodePlotFragment from '../queries/dimensionalNodePlot';
+import { STREAM_FIELD_FRAGMENT } from 'components/common/StreamField';
 
 const OUTCOME_NODE_FIELDS = gql`
   fragment OutcomeNodeFields on Node {
@@ -111,16 +112,12 @@ const GET_PAGE = gql`
       }
       ... on StaticPage {
         body {
-          id
-          __typename
-          ... on RichTextBlock {
-            value
-            rawValue
-          }
+          ...StreamFieldFragment
         }
       }
     }
   }
+  ${STREAM_FIELD_FRAGMENT}
 `;
 
 export default GET_PAGE;


### PR DESCRIPTION
- Show `card.body` i.e. Kausal Watch actions on the action packages page
- Add initial `StreamField` component
- Add `CardListBlock`, primarily geared towards Zürich's use case, to be made more generic when needed later

<img width="700" alt="image" src="https://github.com/kausaltech/kausal-paths-ui/assets/15343658/5c6aef57-035e-459c-be4a-c55f7d089a85">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205687635343250