### PR TITLE
Use dimensional node for one year bar graph

### DIFF
--- a/src/components/general/BarGraph.tsx
+++ b/src/components/general/BarGraph.tsx
@@ -9,6 +9,12 @@ import type { PlotParams } from 'react-plotly.js';
 
 const Plot = dynamic(() => import('components/graphs/Plot'), { ssr: false });
 
+const BarGraphContainer = styled.div`
+  margin: 0 auto;
+  min-width: 300px;
+  max-width: 600px;
+`;
+
 const PlotLoader = styled.div`
   height: 350px;
   display: flex;
@@ -136,6 +142,15 @@ const BarGraph = (props: BarGraphProps) => {
     subNodes?.length > 1 ? subNodes : parentNode && [parentNode];
   const shortUnit = metric.unit?.short;
 
+  let longUnit = parentNode.metric?.unit?.htmlShort;
+  // FIXME: Another nasty hack to show 'CO2e' where it might be applicable until
+  // the backend gets proper support for unit specifiers.
+  if (shortUnit === 't/Einw./a') {
+    longUnit = t('tco2-e-inhabitant');
+  } else if (shortUnit === 'kt/a') {
+    longUnit = t('ktco2-e');
+  }
+
   const barTraces = makeTrace(parentNode, displayNodes, endYear, theme, t);
 
   // Add some buffer to y-axis range to accommodate % labels
@@ -146,6 +161,15 @@ const BarGraph = (props: BarGraphProps) => {
     height: 350,
     hovermode: false,
     barmode: 'stack',
+    title: {
+      text: endYear + '',
+      font: {
+        family: theme.fontFamily,
+        size: 20,
+      },
+      xref: 'paper',
+      x: 0,
+    },
     annotations: [
       // Places y-axis title on top of the y-axis
       {
@@ -156,8 +180,9 @@ const BarGraph = (props: BarGraphProps) => {
         xanchor: 'left',
         y: 1,
         yanchor: 'bottom',
-        text: shortUnit || undefined,
+        text: longUnit || undefined,
         font: {
+          family: theme.fontFamily,
           size: 14,
         },
         showarrow: false,
@@ -165,9 +190,16 @@ const BarGraph = (props: BarGraphProps) => {
     ],
     yaxis: {
       range: range,
+      tickfont: {
+        family: theme.fontFamily,
+      },
     },
     xaxis: {
       type: 'category',
+      tickfont: {
+        family: theme.fontFamily,
+        size: 9,
+      },
     },
     showlegend: true,
     legend: {
@@ -180,7 +212,7 @@ const BarGraph = (props: BarGraphProps) => {
   };
 
   return (
-    <div>
+    <BarGraphContainer>
       {loading && (
         <PlotLoader>
           <Spinner color="dark" />
@@ -192,9 +224,9 @@ const BarGraph = (props: BarGraphProps) => {
         useResizeHandler
         config={{ displayModeBar: false, responsive: true, staticPlot: true }}
         onInitialized={() => setLoading(false)}
-        style={{ minWidth: '300px', maxWidth: '600px', margin: '0 auto' }}
+        style={{ minWidth: '300px', maxWidth: '600px' }}
       />
-    </div>
+    </BarGraphContainer>
   );
 };
 

--- a/src/components/general/DimensionalBarGraph.tsx
+++ b/src/components/general/DimensionalBarGraph.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useMemo, useState } from 'react';
+import dynamic from 'next/dynamic';
+import { useTranslation } from 'next-i18next';
+import { useReactiveVar } from '@apollo/client';
+import type { DimensionalNodeMetricFragment } from 'common/__generated__/graphql';
+
+import { activeGoalVar } from 'common/cache';
+import { DimensionalMetric, SliceConfig } from 'data/metric';
+import { useTheme } from 'common/theme';
+import { InstanceGoal } from 'common/instance';
+import { isEqual } from 'lodash';
+
+const Plot = dynamic(() => import('components/graphs/Plot'), { ssr: false });
+
+function getDefaultSliceConfig(
+  cube: DimensionalMetric,
+  activeGoal: InstanceGoal | null
+) {
+  /**
+   * By default, we group by the first dimension `metric` has, whatever it is.
+   * @todo Is there a better way to select the default?
+   *
+   * If the currently selected goal has category selections for this metric,
+   * we might choose another dimension.
+   *
+   * NOTE: This is just the default -- the actually active filtering and
+   * grouping is controlled by the `sliceConfig` state below.
+   */
+  const defaultConfig: SliceConfig = {
+    dimensionId: cube.dimensions[0]?.id,
+    categories: {},
+  };
+
+  if (!activeGoal) return defaultConfig;
+
+  const cubeDefault = cube.getChoicesForGoal(activeGoal);
+  if (!cubeDefault) return defaultConfig;
+  defaultConfig.categories = cubeDefault;
+  /**
+   * Check if our default dimension to slice by is affected by the
+   * goal-based default filters. If so, we should choose another
+   * dimension.
+   */
+  if (
+    defaultConfig.dimensionId &&
+    cubeDefault.hasOwnProperty(defaultConfig.dimensionId)
+  ) {
+    const firstPossible = cube.dimensions.find(
+      (dim) => !cubeDefault.hasOwnProperty(dim.id)
+    );
+    defaultConfig.dimensionId = firstPossible?.id;
+  }
+  return defaultConfig;
+}
+
+type DimensionalBarGraphProps = {
+  metric: NonNullable<DimensionalNodeMetricFragment['metricDim']>;
+  endYear: number;
+  color?: string | null;
+};
+
+const DimensionalBarGraph = ({ metric, endYear }: DimensionalBarGraphProps) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const activeGoal = useReactiveVar(activeGoalVar);
+  const cube = useMemo(() => new DimensionalMetric(metric), [metric]);
+  const defaultConfig = getDefaultSliceConfig(cube, activeGoal);
+  const [sliceConfig, setSliceConfig] = useState<SliceConfig>(defaultConfig);
+
+  useEffect(() => {
+    /**
+     * If the active goal changes, we will reset the grouping + filtering
+     * to be compatible with the new choices (if the new goal has common
+     * dimensions with our metric).
+     */
+    if (!activeGoal) return;
+    const newDefault = getDefaultSliceConfig(cube, activeGoal);
+    if (!newDefault || isEqual(sliceConfig, newDefault)) return;
+    setSliceConfig(newDefault);
+  }, [activeGoal, cube]);
+
+  const yearData = cube.getSingleYear(endYear, sliceConfig.categories);
+
+  const plotData: Partial<Plotly.PlotData>[] = [];
+
+  let longUnit = metric.unit.htmlShort;
+  // FIXME: Nasty hack to show 'CO2e' where it might be applicable until
+  // the backend gets proper support for unit specifiers.
+  if (
+    cube.hasDimension('emission_scope') &&
+    !cube.hasDimension('greenhouse_gases')
+  ) {
+    if (metric.unit.short === 't/Einw./a') {
+      longUnit = t('tco2-e-inhabitant');
+    } else if (metric.unit.short === 'kt/a') {
+      longUnit = t('ktco2-e');
+    }
+  }
+
+  let maxTotal = 0;
+  yearData.categoryTypes[1].options.forEach((colId, cIdx) => {
+    const colTotals = yearData.rows.reduce((acc, row) => {
+      return row[cIdx] + acc;
+    }, 0);
+    // Remember the largest total for scaling the y-axis
+    if (Math.abs(colTotals) > maxTotal) {
+      maxTotal = Math.abs(colTotals);
+    }
+    yearData.categoryTypes[0].options.forEach((rowId, rIdx) => {
+      const datum = yearData.rows[rIdx][cIdx];
+      const portion = datum / colTotals;
+      const displayPortions =
+        portion >= 0.01 ? Math.round((datum / colTotals) * 100) : '<1';
+      const textTemplate =
+        portion && portion !== 1 && portion !== 0 ? '%{meta[0]}%' : '';
+      const dimDetails = yearData.allLabels.find((l) => l.id === rowId);
+      plotData.push({
+        type: 'bar',
+        x: [yearData.allLabels.find((l) => l.id === colId)?.label],
+        y: [datum],
+        meta: [displayPortions],
+        textposition: 'outside',
+        texttemplate: textTemplate,
+        textangle: 0,
+        name: dimDetails?.label,
+        base: datum < 0 ? [-datum] : undefined,
+        marker: {
+          color: dimDetails?.color || theme.graphColors.grey050,
+        },
+      });
+    });
+  });
+
+  const range = [0, maxTotal * 1.1];
+
+  const layout: Partial<Plotly.Layout> = {
+    height: 400,
+    hovermode: false,
+    barmode: 'stack',
+    title: {
+      text: endYear + '',
+      font: {
+        family: theme.fontFamily,
+        size: 20,
+      },
+      xref: 'paper',
+      x: 0,
+    },
+    annotations: [
+      // Places y-axis title on top of the y-axis
+      {
+        xref: 'paper',
+        yref: 'paper',
+        yshift: 10,
+        x: 0,
+        xanchor: 'left',
+        y: 1,
+        yanchor: 'bottom',
+        text: longUnit || undefined,
+        font: {
+          family: theme.fontFamily,
+          size: 14,
+        },
+        showarrow: false,
+      },
+    ],
+    yaxis: {
+      range: range,
+      tickfont: {
+        family: theme.fontFamily,
+      },
+    },
+    xaxis: {
+      tickfont: {
+        family: theme.fontFamily,
+      },
+    },
+    showlegend: false,
+  };
+
+  return (
+    <>
+      <div className="mt-3">
+        <Plot
+          data={plotData}
+          layout={layout}
+          useResizeHandler
+          config={{ displayModeBar: false, responsive: true, staticPlot: true }}
+          style={{ minWidth: '300px', maxWidth: '600px' }}
+          noValidate
+        />
+      </div>
+    </>
+  );
+};
+
+export default DimensionalBarGraph;

--- a/src/components/general/DimensionalBarGraph.tsx
+++ b/src/components/general/DimensionalBarGraph.tsx
@@ -124,6 +124,7 @@ const DimensionalBarGraph = ({ metric, endYear }: DimensionalBarGraphProps) => {
         textangle: 0,
         name: dimDetails?.label,
         base: datum < 0 ? [-datum] : undefined,
+        width: 0.5,
         marker: {
           color: dimDetails?.color || theme.graphColors.grey050,
         },

--- a/src/components/general/DimensionalBarGraph.tsx
+++ b/src/components/general/DimensionalBarGraph.tsx
@@ -127,11 +127,12 @@ const DimensionalBarGraph = ({ metric, endYear }: DimensionalBarGraphProps) => {
         marker: {
           color: dimDetails?.color || theme.graphColors.grey050,
         },
+        showlegend: datum !== 0,
       });
     });
   });
 
-  const range = [0, maxTotal * 1.1];
+  const range = [0, maxTotal * 1.25];
 
   const layout: Partial<Plotly.Layout> = {
     height: 400,
@@ -164,6 +165,21 @@ const DimensionalBarGraph = ({ metric, endYear }: DimensionalBarGraphProps) => {
         showarrow: false,
       },
     ],
+    modebar: {
+      remove: [
+        'zoom2d',
+        'zoomIn2d',
+        'zoomOut2d',
+        'pan2d',
+        'select2d',
+        'lasso2d',
+        'autoScale2d',
+        'resetScale2d',
+      ],
+      color: theme.graphColors.grey090,
+      bgcolor: theme.graphColors.grey010,
+      activecolor: theme.brandDark,
+    },
     yaxis: {
       range: range,
       tickfont: {
@@ -175,7 +191,22 @@ const DimensionalBarGraph = ({ metric, endYear }: DimensionalBarGraphProps) => {
         family: theme.fontFamily,
       },
     },
-    showlegend: false,
+    dragmode: false,
+    showlegend: true,
+    legend: {
+      orientation: 'h',
+      yanchor: 'top',
+      y: -0.2,
+      xanchor: 'right',
+      x: 1,
+      itemclick: false,
+      itemdoubleclick: false,
+    },
+  };
+
+  const plotConfig = {
+    displaylogo: false,
+    responsive: true,
   };
 
   return (
@@ -185,7 +216,7 @@ const DimensionalBarGraph = ({ metric, endYear }: DimensionalBarGraphProps) => {
           data={plotData}
           layout={layout}
           useResizeHandler
-          config={{ displayModeBar: false, responsive: true, staticPlot: true }}
+          config={plotConfig}
           style={{ minWidth: '300px', maxWidth: '600px' }}
           noValidate
         />

--- a/src/components/general/OutcomeNodeContent.tsx
+++ b/src/components/general/OutcomeNodeContent.tsx
@@ -12,8 +12,7 @@ import {
   getMetricChange,
 } from 'common/preprocess';
 import HighlightValue from 'components/general/HighlightValue';
-import OutcomeGraph from 'components/general/OutcomeGraph';
-import BarGraph from 'components/general/BarGraph';
+import DimensionalBarGraph from 'components/general/DimensionalBarGraph';
 import DataTable from './DataTable';
 import OutcomeNodeDetails from './OutcomeNodeDetails';
 import { OutcomeNodeFieldsFragment } from 'common/__generated__/graphql';
@@ -157,20 +156,16 @@ const OutcomeNodeContent = ({
         withTools={false}
       />
     ),
-    [node, subNodes, color, startYear, endYear]
+    [node, color, startYear, endYear]
   );
 
   const singleYearGraph = useMemo(
     () => (
-      <BarGraph
-        node={node}
-        subNodes={subNodes}
-        color={color}
-        startYear={startYear}
-        endYear={endYear}
-      />
+      <div>
+        <DimensionalBarGraph metric={node.metricDim!} endYear={endYear} />
+      </div>
     ),
-    [node, subNodes, color, startYear, endYear]
+    [node, endYear, color]
   );
 
   return (


### PR DESCRIPTION
Data crunching for getting the two dimensional data for the singe year is probably not bulletproof but seems to work in the test case

before:
![Screenshot 2023-11-19 at 18 33 09](https://github.com/kausaltech/kausal-paths-ui/assets/664877/aed0c108-b72a-4d9f-8082-4e7b217c4cef)


after: 
![Screenshot 2023-11-19 at 18 36 47](https://github.com/kausaltech/kausal-paths-ui/assets/664877/f7276dd2-caee-4d0e-99c0-6ed84c978379)

