### PR TITLE
Show action body when no subactions exist

### DIFF
--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -688,7 +688,25 @@ export type GetActionContentQuery = (
         & { __typename: 'ForecastMetricType' }
       ) | null }
       & { __typename: 'Node' }
-    )>, subactions: Array<(
+    )>, body: Array<(
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CharBlock' | 'ChoiceBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'FloatBlock' | 'ImageChooserBlock' | 'IntegerBlock' | 'ListBlock' | 'PageChooserBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'StaticBlock' | 'StreamBlock' | 'StreamFieldBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'StructBlock' | 'TimeBlock' | 'URLBlock' }
+    ) | (
+      { blockType: string, title: string | null, id: string | null, field: string, cards: Array<(
+        { title: string | null, shortDescription: string | null }
+        & { __typename: 'CardListCardBlock' }
+      ) | null> | null }
+      & { __typename: 'CardListBlock' }
+    ) | (
+      { value: string, rawValue: string, id: string | null, blockType: string, field: string }
+      & { __typename: 'RichTextBlock' }
+    ) | (
+      { value: string, id: string | null, blockType: string, field: string }
+      & { __typename: 'TextBlock' }
+    )> | null, subactions: Array<(
       { id: string, name: string, description: string | null, goal: any | null, shortDescription: any | null, isEnabled: boolean, isVisible: boolean, parameters: Array<(
         { id: string }
         & { __typename: 'BoolParameterType' | 'NumberParameterType' | 'StringParameterType' | 'UnknownParameterType' }

--- a/src/queries/getActionContent.js
+++ b/src/queries/getActionContent.js
@@ -18,6 +18,9 @@ const GET_ACTION_CONTENT = gql`
         ...CausalGridNode
       }
       decisionLevel
+      body {
+        ...StreamFieldFragment
+      }
       subactions {
         id
         name


### PR DESCRIPTION
Zürich would like to show their measures (part of an action body) even when that action has no sub-actions. Until now we've only supported rendering the body of sub-actions, this change falls back to the action body if there aren't any sub-actions. 

In future, we should support rendering both action body and sub-actions at the same time, but for now Zürich have duplicate data in their action/ sub-action bodies. 

<img width="1261" alt="image" src="https://github.com/kausaltech/kausal-paths-ui/assets/15343658/89c79c60-dfcf-4d80-9119-d61d56e1b84d">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205990103205012