### PR TITLE
Add frontend support for additional languages

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,4 +1,14 @@
-const SUPPORTED_LANGUAGES = ['en', 'fi', 'sv', 'de', 'de-CH'];
+const SUPPORTED_LANGUAGES = [
+  'en',
+  'fi',
+  'sv',
+  'de',
+  'de-CH',
+  'cs',
+  'da',
+  'lv',
+  'pl',
+];
 
 /**
  * @type {import('next-i18next').UserConfig}

--- a/src/common/i18n.ts
+++ b/src/common/i18n.ts
@@ -7,6 +7,10 @@ import numbroEnGb from 'numbro/dist/languages/en-GB.min.js';
 import numbroFi from 'numbro/dist/languages/fi-FI.min.js';
 import numbroDe from 'numbro/dist/languages/de-DE.min.js';
 import numbroDeCh from 'numbro/dist/languages/de-CH.min.js';
+import numbroCs from 'numbro/dist/languages/cs-CZ.min.js';
+import numbroDa from 'numbro/dist/languages/da-DK.min.js';
+import numbroLv from 'numbro/dist/languages/lv-LV.min.js';
+import numbroPl from 'numbro/dist/languages/pl-PL.min.js';
 
 const numbroLangs = {
   de: numbroDe,
@@ -14,6 +18,10 @@ const numbroLangs = {
   'de-CH': numbroDeCh,
   'en-GB': numbroEnGb,
   fi: numbroFi,
+  cs: numbroCs,
+  da: numbroDa,
+  lv: numbroLv,
+  pl: numbroPl,
 };
 
 Object.entries(numbroLangs).forEach(([lang, conf]) => {

--- a/src/components/general/LanguageSelector.tsx
+++ b/src/components/general/LanguageSelector.tsx
@@ -60,6 +60,10 @@ const languageNames = {
   en: 'English',
   de: 'Deutsch',
   sv: 'Svenska',
+  cs: 'Čeština',
+  da: 'Dansk',
+  lv: 'Latviešu',
+  pl: 'Polski',
 };
 
 function LanguageSelector({ mobile }: { mobile: boolean }) {

--- a/src/components/graphs/Plot.tsx
+++ b/src/components/graphs/Plot.tsx
@@ -1,3 +1,4 @@
+import React, { useEffect, useLayoutEffect, useRef } from 'react';
 import { useTranslation } from 'next-i18next';
 import type { PlotParams } from 'react-plotly.js';
 import createPlotlyComponent from 'react-plotly.js/factory';
@@ -6,14 +7,12 @@ import fi from 'plotly.js-locales/fi';
 import sv from 'plotly.js-locales/sv';
 import de from 'plotly.js-locales/de';
 import de_ch from 'plotly.js-locales/de-ch';
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import cs from 'plotly.js-locales/cs';
+import da from 'plotly.js-locales/da';
+import lv from 'plotly.js-locales/lv';
+import pl from 'plotly.js-locales/pl';
 
-const locales = {
-  fi,
-  sv,
-  de,
-  'de-CH': de_ch,
-};
+const locales = { fi, sv, de, 'de-CH': de_ch, cs, da, lv, pl };
 
 const PlotlyPlot = createPlotlyComponent(Plotly);
 
@@ -31,18 +30,32 @@ const Plot = (props: PlotProps) => {
 
   config.locales = locales;
   config.locale = lang;
-  if (lang == 'fi') {
-    separators = ', ';
-  } else if (lang == 'sv') {
-    separators = '.,';
-  } else if (lang == 'en') {
-    separators = '.,';
-  } else if (lang == 'de') {
-    config.locale = 'de';
-    separators = ',.';
-  } else if (lang == 'de-CH') {
-    config.locale = 'de-CH';
-    separators = ".'";
+
+  switch (lang) {
+    case 'fi':
+      separators = ', ';
+      break;
+    case 'de':
+      config.locale = 'de';
+      separators = ',.';
+      break;
+    case 'de-CH':
+      config.locale = 'de-CH';
+      separators = ".'";
+      break;
+    case 'cs':
+    case 'da':
+    case 'pl':
+      separators = '.,';
+      break;
+    case 'lv':
+      separators = ',.';
+      break;
+    case 'sv':
+    case 'en':
+    default:
+      separators = '.,';
+      break;
   }
 
   config.responsive = true;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -274,7 +274,10 @@ async function getSiteContext(ctx: PathsPageContext, locale: string) {
     };
   } catch (error) {
     if (isApolloError(error)) {
-      console.error('Got Apollo error while fetching instance context');
+      console.error(
+        'Got Apollo error while fetching instance context',
+        JSON.stringify(error, null, 2)
+      );
       const isProtected = error.graphQLErrors.find(
         (err) => err.extensions?.code == 'instance_protected'
       );


### PR DESCRIPTION
Adds frontend support for four additional languages (Czech, Danish, Latvian and Polish) to the
- Language selector dropdown
- Plotly translations
- Numbro translations
- Custom number separators