### PR TITLE
Intromodal to use introContent instead of hardcoded video

### DIFF
--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -1711,7 +1711,10 @@ export type GetInstanceContextQuery = (
     { id: string, name: string, themeIdentifier: string | null, owner: string | null, defaultLanguage: string, supportedLanguages: Array<string>, targetYear: number | null, modelEndYear: number, referenceYear: number | null, minimumHistoricalYear: number, maximumHistoricalYear: number | null, leadTitle: string | null, leadParagraph: string | null, features: (
       { baselineVisibleInGraphs: boolean, showAccumulatedEffects: boolean, showSignificantDigits: number }
       & { __typename: 'InstanceFeaturesType' }
-    ), goals: Array<(
+    ), introContent: Array<{ __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardListBlock' | 'CharBlock' | 'ChoiceBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'FloatBlock' | 'ImageChooserBlock' | 'IntegerBlock' | 'ListBlock' | 'PageChooserBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'StaticBlock' | 'StreamBlock' } | { __typename: 'StreamFieldBlock' | 'StructBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | (
+      { field: string, value: string }
+      & { __typename: 'RichTextBlock' }
+    )> | null, goals: Array<(
       { id: string, label: string | null, default: boolean, disabled: boolean, outcomeNode: (
         { id: string }
         & { __typename: 'Node' }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -12,7 +12,6 @@ import { useCustomComponent } from './custom';
 import { useTranslation } from 'common/i18n';
 import IntroModal from './common/IntroModal';
 import { useInstance } from 'common/instance';
-import RichText from 'components/common/RichText';
 
 const PageContainer = styled.div`
   width: 100%;
@@ -95,7 +94,22 @@ const Layout = ({ children }) => {
   const FooterComponent = useCustomComponent('Footer', Footer);
 
   const instance = useInstance();
-  const introModalEnabled = instance.id === 'zuerich';
+
+  const title = instance.introContent?.find(
+    (
+      block
+    ): block is { __typename: 'RichTextBlock'; field: string; value: string } =>
+      block.__typename === 'RichTextBlock' && block.field === 'title'
+  )?.value;
+
+  const paragraph = instance.introContent?.find(
+    (
+      block
+    ): block is { __typename: 'RichTextBlock'; field: string; value: string } =>
+      block.__typename === 'RichTextBlock' && block.field === 'paragraph'
+  )?.value;
+
+  const introModalEnabled = !!(title && paragraph);
 
   return (
     <>
@@ -135,16 +149,7 @@ const Layout = ({ children }) => {
       <FooterContainer>
         <FooterComponent />
       </FooterContainer>
-      {introModalEnabled && (
-        <IntroModal>
-          <RichText
-            html={`<iframe width="100%" style="aspect-ratio: 16 / 9"
-                src="https://www.youtube.com/embed/vBLbQTgZJns?autoplay=1"
-                title="Intro Video" allowFullScreen>
-              </iframe>`}
-          />
-        </IntroModal>
-      )}
+      {introModalEnabled && <IntroModal title={title} paragraph={paragraph} />}
     </>
   );
 };

--- a/src/components/common/IntroModal.tsx
+++ b/src/components/common/IntroModal.tsx
@@ -11,6 +11,7 @@ import {
   Input,
 } from 'reactstrap';
 import styled from 'styled-components';
+import RichText from './RichText';
 
 const StyledButton = styled(Button)`
   background-color: ${(props) => props.theme.brandDark};
@@ -55,9 +56,16 @@ const StyledModalFooter = styled(ModalFooter)`
 interface IntroModalProps {
   size?: string;
   children: ReactNode;
+  title: string;
+  paragraph: string;
 }
 
-const IntroModal = ({ size = 'lg', children }: IntroModalProps) => {
+const IntroModal = ({
+  size = 'lg',
+  children,
+  title,
+  paragraph,
+}: IntroModalProps) => {
   const { t } = useTranslation();
   const [enabled, setEnabled] = useState(true);
   const [isChecked, setIsChecked] = useState(true);
@@ -86,9 +94,11 @@ const IntroModal = ({ size = 'lg', children }: IntroModalProps) => {
     <div>
       <Modal isOpen={enabled} toggle={handleClose} size={size} fade={true}>
         <StyledModalHeader toggle={handleClose}>
-          So funktioniert das Netto-Null-Cockpit
+          <RichText html={title} />
         </StyledModalHeader>
-        <ModalBody>{children}</ModalBody>
+        <ModalBody>
+          <RichText html={paragraph} />
+        </ModalBody>
         <StyledModalFooter>
           <StyledContainer>
             <FormGroup check>

--- a/src/components/common/RichText.tsx
+++ b/src/components/common/RichText.tsx
@@ -57,7 +57,7 @@ const StyledRichText = styled.div`
   .responsive-object {
     padding-bottom: 0 !important;
     width: 100%;
-    max-width: ${(props) => props.theme.breakpointSm};
+    max-width: ${(props) => props.theme.breakpointLg};
   }
   .responsive-object iframe {
     aspect-ratio: 16 / 9;

--- a/src/queries/instance.ts
+++ b/src/queries/instance.ts
@@ -31,6 +31,14 @@ const GET_INSTANCE_CONTEXT = gql`
         showAccumulatedEffects
         showSignificantDigits
       }
+      introContent {
+        ... on StreamFieldInterface {
+          ... on RichTextBlock {
+            field
+            value
+          }
+        }
+      }
       goals {
         id
         label


### PR DESCRIPTION
Introductory content in modal to use data from introContent streamfield block instead of hardcoded.

![image](https://github.com/kausaltech/kausal-paths-ui/assets/6697396/46bdf0ef-4879-4202-a437-c9a263457a19)


Asana: https://app.asana.com/0/1206017643443542/1205885283442145

Depending on Backend:  https://github.com/kausaltech/kausal-paths/pull/37