### PR TITLE
Take baseline into account when defining plot range

### DIFF
--- a/src/components/general/DimensionalNodePlot.tsx
+++ b/src/components/general/DimensionalNodePlot.tsx
@@ -486,6 +486,26 @@ export default function DimensionalNodePlot({
     visible: false,
   };
 
+  // Take baseline data into account when deciding the custom y-range for the graph
+  const baselineRange = baselineForecast
+    ? getRange(baselineForecast?.map((item) => item.value))
+    : [undefined, undefined];
+  const dataRange =
+    metric.stackable && slice.totalValues
+      ? getRangeFromSlice(slice)
+      : [undefined, undefined];
+
+  const rangeMin =
+    dataRange[0] && baselineRange[0]
+      ? Math.min(dataRange[0], baselineRange[0])
+      : dataRange[0];
+  const rangeMax =
+    dataRange[1] && baselineRange[1]
+      ? Math.max(dataRange[1], baselineRange[1])
+      : dataRange[1];
+
+  const customRange = rangeMin && rangeMax ? [rangeMin, rangeMax] : undefined;
+
   const layout: Partial<Plotly.Layout> = {
     height: 300,
     margin: {
@@ -524,10 +544,7 @@ export default function DimensionalNodePlot({
       tickcolor: theme.graphColors.grey030,
       fixedrange: true,
       rangemode: rangeMode,
-      range:
-        metric.stackable && slice.totalValues
-          ? getRangeFromSlice(slice)
-          : undefined,
+      range: customRange,
     },
     xaxis: showReferenceYear
       ? {


### PR DESCRIPTION
Before
<img width="865" alt="Screenshot 2024-06-04 at 15 57 13" src="https://github.com/kausaltech/kausal-paths-ui/assets/664877/3c0b9121-3cfa-4c16-81d7-91c6be788c44">

After
<img width="875" alt="Screenshot 2024-06-04 at 15 59 20" src="https://github.com/kausaltech/kausal-paths-ui/assets/664877/59bd16b7-c762-4d0d-b7b2-bfa6b56a4e63">


https://app.asana.com/0/1202855459841144/1206611753989232/f