### PR TITLE
Show outcome sector cards even without value

### DIFF
--- a/src/components/general/OutcomeCard.tsx
+++ b/src/components/general/OutcomeCard.tsx
@@ -65,6 +65,15 @@ const MainValue = styled.div`
   font-weight: 700;
 `;
 
+const NoValue = styled.div`
+  text-align: left;
+  font-weight: 700;
+  color: ${({ theme }) => theme.graphColors.grey030};
+  &:before {
+    content: '—';
+  }
+`;
+
 const Label = styled.div<{ $active?: boolean }>`
   font-size: 0.7rem;
   font-weight: 700;
@@ -171,8 +180,6 @@ const OutcomeCard = (props: OutcomeCardProps) => {
 
   // const unit = `kt CO<sub>2</sub>e${t('abbr-per-annum')}`;
   const unit = node.metric?.unit?.htmlShort;
-  // If there is no outcome  value for active year, do not display card set
-  if (goalOutcomeValue === undefined) return null;
 
   const handleClickTab = () => handleClick(node.id);
 
@@ -215,29 +222,39 @@ const OutcomeCard = (props: OutcomeCardProps) => {
             <Name>{node.shortName || node.name}</Name>
           </Title>
         </Header>
-        {true && (
-          <Body>
-            <MainValue>
-              <Label $active={active}>
-                {isForecast
-                  ? t('table-scenario-forecast')
-                  : t('table-historical')}{' '}
-                {endYear}
+
+        <Body>
+          <MainValue>
+            <Label $active={active}>
+              {isForecast
+                ? t('table-scenario-forecast')
+                : t('table-historical')}{' '}
+              {endYear}
+            </Label>
+            {goalOutcomeValue ? (
+              <>
+                {beautifyValue(goalOutcomeValue)}
+                <MainUnit dangerouslySetInnerHTML={{ __html: unit || '' }} />
+              </>
+            ) : (
+              <NoValue />
+            )}
+
+            <Status>
+              <Label>
+                {t('change-over-time')} {startYear} - {endYear}
               </Label>
-              {beautifyValue(goalOutcomeValue)}
-              <MainUnit dangerouslySetInnerHTML={{ __html: unit || '' }} />
-              {change && (
-                <Status>
-                  <Label>
-                    {t('change-over-time')} {startYear} - {endYear}
-                  </Label>
+              {change ? (
+                <>
                   {change > 0 && <span>+</span>}
                   {change ? <span>{`${change}%`}</span> : <span>-</span>}
-                </Status>
+                </>
+              ) : (
+                <NoValue />
               )}
-            </MainValue>
-          </Body>
-        )}
+            </Status>
+          </MainValue>
+        </Body>
       </DashCard>
     </StyledTab>
   );

--- a/src/components/general/OutcomeCardSet.tsx
+++ b/src/components/general/OutcomeCardSet.tsx
@@ -54,7 +54,7 @@ const Bar = styled.div`
 
 const BarHeader = styled.h5`
   font-size: 1rem;
-  color: ${(props) => props.theme.graphColors.grey060};
+  color: ${({ theme }) => theme.textColor.tertiary};
 `;
 
 const Segment = styled.div`
@@ -223,11 +223,7 @@ const OutcomeCardSet = ({
   const { cardNodes, subNodeMap } = useMemo(() => {
     const inputNodeIds = rootNode.inputNodes.map((node) => node.id);
     const cardNodes = [...nodeMap.values()]
-      .filter(
-        (node) =>
-          inputNodeIds.indexOf(node.id) >= 0 &&
-          getMetricValue(node, endYear) !== undefined
-      )
+      .filter((node) => inputNodeIds.indexOf(node.id) >= 0)
       .map((node) => ({ ...node }));
     orderByMetric(cardNodes);
     setUniqueColors(


### PR DESCRIPTION
Display all available subsector cards even if they do not have values for selected year range

Before
<img width="1143" alt="Screenshot 2024-06-06 at 10 41 05" src="https://github.com/kausaltech/kausal-paths-ui/assets/664877/1d25bdeb-6dda-45b3-ab59-2c4f36871b7e">

After
<img width="1146" alt="Screenshot 2024-06-06 at 10 40 44" src="https://github.com/kausaltech/kausal-paths-ui/assets/664877/ec997577-6979-495b-9b40-00295527eaa4">
