### PR TITLE
Fix backend-originating strings not getting translated

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,4 +1,4 @@
-const SUPPORTED_LANGUAGES = ['en', 'fi', 'sv', 'de', 'de-CH', 'cs', 'da', 'lv', 'pl'];
+const SUPPORTED_LANGUAGES = ['en', 'fi', 'sv', 'de', 'de-CH', 'cs', 'da', 'lv', 'pl', 'es-US'];
 
 /**
  * @type {import('next-i18next').UserConfig}

--- a/src/common/apollo.ts
+++ b/src/common/apollo.ts
@@ -143,14 +143,12 @@ const makeInstanceMiddleware = (opts: ApolloClientOpts) => {
    *
    * If identifier is set directly, use that, or fall back to request hostname.
    */
-  const { instanceHostname, instanceIdentifier } = opts;
+  const { instanceHostname, instanceIdentifier, locale } = opts;
   if (!instanceHostname && !instanceIdentifier) {
     throw new Error('Neither hostname or identifier set for the instance');
   }
 
   const middleware = new ApolloLink((operation, forward) => {
-    const context = operation.getContext();
-    const locale = context?.locale;
     operation.query = {
       ...operation.query,
       definitions: operation.query.definitions.map((def) => {

--- a/src/common/i18n.ts
+++ b/src/common/i18n.ts
@@ -11,6 +11,23 @@ import numbroCs from 'numbro/dist/languages/cs-CZ.min.js';
 import numbroDa from 'numbro/dist/languages/da-DK.min.js';
 import numbroLv from 'numbro/dist/languages/lv-LV.min.js';
 import numbroPl from 'numbro/dist/languages/pl-PL.min.js';
+import numbroEs from 'numbro/dist/languages/es-ES.min.js';
+
+function numbroEsUs() {
+  const esUs = numbroEs;
+  esUs.languageTag = 'es-US';
+  esUs.delimiters = {
+    thousands: ',',
+    decimal: '.',
+  };
+  esUs.currency = {
+    symbol: '$',
+    position: 'prefix',
+    code: 'USD',
+  };
+
+  return esUs;
+}
 
 const numbroLangs = {
   de: numbroDe,
@@ -22,6 +39,7 @@ const numbroLangs = {
   da: numbroDa,
   lv: numbroLv,
   pl: numbroPl,
+  'es-US': numbroEsUs(),
 };
 
 Object.entries(numbroLangs).forEach(([lang, conf]) => {
@@ -31,8 +49,7 @@ Object.entries(numbroLangs).forEach(([lang, conf]) => {
   });
 });
 
-const { appWithTranslation, withTranslation, Trans, useTranslation } =
-  NextI18Next;
+const { appWithTranslation, withTranslation, Trans, useTranslation } = NextI18Next;
 
 export function getI18n() {
   return NextI18Next.i18n;

--- a/src/components/general/LanguageSelector.tsx
+++ b/src/components/general/LanguageSelector.tsx
@@ -56,6 +56,7 @@ const languageNames = {
   da: 'Dansk',
   lv: 'Latviešu',
   pl: 'Polski',
+  es: 'Español',
 };
 
 function LanguageSelector({ mobile }: { mobile: boolean }) {

--- a/src/components/graphs/Plot.tsx
+++ b/src/components/graphs/Plot.tsx
@@ -6,6 +6,7 @@ import cs from 'plotly.js-locales/cs';
 import da from 'plotly.js-locales/da';
 import de from 'plotly.js-locales/de';
 import de_ch from 'plotly.js-locales/de-ch';
+import es from 'plotly.js-locales/es';
 import fi from 'plotly.js-locales/fi';
 import lv from 'plotly.js-locales/lv';
 import pl from 'plotly.js-locales/pl';
@@ -13,7 +14,7 @@ import sv from 'plotly.js-locales/sv';
 import type { PlotParams } from 'react-plotly.js';
 import createPlotlyComponent from 'react-plotly.js/factory';
 
-const locales = { fi, sv, de, 'de-CH': de_ch, cs, da, lv, pl };
+const locales = { fi, sv, de, 'de-CH': de_ch, cs, da, lv, pl, 'es-US': es };
 
 const PlotlyPlot = createPlotlyComponent(Plotly);
 
@@ -54,6 +55,10 @@ const Plot = (props: PlotProps) => {
       break;
     case 'sv':
     case 'en':
+    case 'es-US':
+      config.locale = 'es-US';
+      separators = '.,';
+      break;
     default:
       separators = '.,';
       break;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -225,7 +225,6 @@ async function getSiteContext(ctx: PathsPageContext, i18nConf: SiteI18nConfig) {
     >({
       query: GET_INSTANCE_CONTEXT,
       context: {
-        locale: i18nConf.locale,
         logger,
       },
     });


### PR DESCRIPTION
- Add Spanish (United States) to supported languages
- Use locale directive in all GraphQL queries to make sure translated strings are always fetched