### PR TITLE
Handle negative values for single forecast stack

### DIFF
--- a/src/components/general/DimensionalNodePlot.tsx
+++ b/src/components/general/DimensionalNodePlot.tsx
@@ -144,6 +144,7 @@ type DimensionalNodePlotProps = {
 };
 
 export default function DimensionalNodePlot({
+  hasNegativeValues,
   withReferenceYear = false,
   metric,
   startYear,
@@ -250,12 +251,6 @@ export default function DimensionalNodePlot({
   }
 
   const unit = metric.unit.htmlShort;
-
-  const hasNegativeValues = useMemo(() => {
-    return slice.categoryValues.some((cv) =>
-      cv.historicalValues.concat(cv.forecastValues).some((value) => value < 0)
-    );
-  }, [slice.categoryValues]);
 
   const genTraces = (cv: MetricCategoryValues, idx: number) => {
     const color = cv.color || colors[idx];

--- a/src/components/general/DimensionalNodePlot.tsx
+++ b/src/components/general/DimensionalNodePlot.tsx
@@ -449,6 +449,9 @@ export default function DimensionalNodePlot({
 
   if (metric.stackable && slice.totalValues) {
     const label = t('plot-total')!;
+    const totalSumX = [...slice.historicalYears, ...slice.forecastYears];
+    const totalSumY = [...slice.totalValues.historicalValues, ...slice.totalValues.forecastValues];
+
     plotData.push({
       xaxis: 'x2',
       type: 'scatter',
@@ -456,14 +459,38 @@ export default function DimensionalNodePlot({
       mode: 'lines',
       line: {
         color: theme.graphColors.grey080,
-        width: hasNegativeValues ? 0.8 : 0,
-        dash: hasNegativeValues ? 'dot' : 'solid',
+        width: 0,
       },
-      x: [...slice.historicalYears, ...slice.forecastYears],
-      y: [...slice.totalValues.historicalValues, ...slice.totalValues.forecastValues],
-      hovertemplate: `<b>${label} %{x}: %{y:,.${maximumFractionDigits ?? 3}r} ${unit}</b><extra></extra>`,
-      showlegend: hasNegativeValues,
+      x: totalSumX,
+      y: totalSumY,
+      ...formatHover(
+        label,
+        theme.graphColors.grey080,
+        unit,
+        null,
+        theme.fontFamily,
+        maximumFractionDigits
+      ),
+      showlegend: false,
     });
+
+    if (hasNegativeValues) {
+      plotData.push({
+        xaxis: 'x2',
+        type: 'scatter',
+        name: label,
+        mode: 'lines',
+        line: {
+          color: theme.graphColors.grey080,
+          width: 0.8,
+          dash: 'dot',
+        },
+        x: totalSumX,
+        y: totalSumY,
+        hoverinfo: 'skip',
+        showlegend: true,
+      });
+    }
   }
 
   const nrYears = usableEndYear - startYear;

--- a/src/components/general/DimensionalNodePlot.tsx
+++ b/src/components/general/DimensionalNodePlot.tsx
@@ -447,23 +447,22 @@ export default function DimensionalNodePlot({
     });
   }
 
-  if (metric.stackable && slice.totalValues && hasNegativeValues) {
+  if (metric.stackable && slice.totalValues) {
+    const label = t('plot-total')!;
     plotData.push({
       xaxis: 'x2',
       type: 'scatter',
-      name: t('plot-total'),
+      name: label,
       mode: 'lines',
       line: {
         color: theme.graphColors.grey080,
-        shape: 'spline',
-        smoothing: 0.8,
-        width: 0.8,
-        dash: 'dot',
+        width: hasNegativeValues ? 0.8 : 0,
+        dash: hasNegativeValues ? 'dot' : 'solid',
       },
       x: [...slice.historicalYears, ...slice.forecastYears],
       y: [...slice.totalValues.historicalValues, ...slice.totalValues.forecastValues],
-      hovertemplate: `<b>${t('plot-total')} %{x}: %{y:,.${maximumFractionDigits ?? 3}r} ${unit}</b><extra></extra>`,
-      showlegend: true,
+      hovertemplate: `<b>${label} %{x}: %{y:,.${maximumFractionDigits ?? 3}r} ${unit}</b><extra></extra>`,
+      showlegend: hasNegativeValues,
     });
   }
 

--- a/src/components/general/DimensionalNodePlot.tsx
+++ b/src/components/general/DimensionalNodePlot.tsx
@@ -382,6 +382,7 @@ export default function DimensionalNodePlot({
           type: 'scatter',
           name: `${t('target')} ${goal.year}`,
           line: lineConfig,
+          hovertemplate: `<b>${t('target')} %{x}: %{y:,.${maximumFractionDigits ?? 3}r} ${unit}</b><extra></extra>`,
         });
       }
     } else if (goals?.length) {

--- a/src/pages/node/[slug].tsx
+++ b/src/pages/node/[slug].tsx
@@ -172,6 +172,10 @@ export default function NodePage() {
     );
   }
 
+  const hasNegativeValues =
+    node.metric?.historicalValues.some((v) => v.value < 0) ||
+    node.metric?.forecastValues.some((v) => v.value < 0);
+
   return (
     <>
       <Head>
@@ -208,6 +212,7 @@ export default function NodePage() {
                     startYear={yearRange[0]}
                     endYear={yearRange[1]}
                     color={node.color}
+                    hasNegativeValues={hasNegativeValues}
                   />
                 </ContentWrapper>
               ) : (


### PR DESCRIPTION
Bugs: 
- Plotly doesn't handle negative values properly in the scenarios where only one stack group available (only forecast years) - related Asana https://app.asana.com/0/1205310117865974/1208262662051225/f
- Hovertemplate issue with the Goal having no units and inconsistent rounding compared to the other categories - Asana https://app.asana.com/0/1205310117865974/1208119780032048/f


* Modified the `genTraces` function to additionally handle scenarios with only one stackGroup;
* Added logic to check for negative values in both forecast and historical years values.
* Conditionally plotted total sum as a line for graphs with negative values (only rendered by the slug component)
* Updated hovertemplate for the Goal trace.
* Fixed an issue where legends were not displayed for graphs with negative values.

Before:
<img width="1061" alt="image" src="https://github.com/user-attachments/assets/42b6ed00-e559-4b38-9cdd-6d28df49dccf">

After:
<img width="1275" alt="Screen Shot 2024-10-10 at 14 25 03" src="https://github.com/user-attachments/assets/2b3cd08d-ff47-4058-9da1-e9493817e4b2">