### PR TITLE
Add a prompt to refresh the data for NetZeroPlanner instances

### DIFF
--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -1814,7 +1814,7 @@ export type GetInstanceContextQueryVariables = Exact<{ [key: string]: never; }>;
 export type GetInstanceContextQuery = (
   { instance: (
     { id: string, name: string, themeIdentifier: string | null, owner: string | null, defaultLanguage: string, supportedLanguages: Array<string>, targetYear: number | null, modelEndYear: number, referenceYear: number | null, minimumHistoricalYear: number, maximumHistoricalYear: number | null, leadTitle: string | null, leadParagraph: string | null, features: (
-      { hideNodeDetails: boolean, maximumFractionDigits: number | null, baselineVisibleInGraphs: boolean, showAccumulatedEffects: boolean, showSignificantDigits: number | null }
+      { hideNodeDetails: boolean, maximumFractionDigits: number | null, baselineVisibleInGraphs: boolean, showAccumulatedEffects: boolean, showSignificantDigits: number | null, showRefreshPrompt: boolean }
       & { __typename: 'InstanceFeaturesType' }
     ), introContent: Array<{ __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardListBlock' | 'CharBlock' | 'ChoiceBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'FloatBlock' | 'ImageChooserBlock' | 'IntegerBlock' | 'ListBlock' | 'PageChooserBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'SnippetChooserBlock' | 'StaticBlock' } | { __typename: 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | (
       { field: string, value: string }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -10,6 +10,7 @@ import styled, { useTheme } from 'styled-components';
 
 import { getThemeStaticURL } from '@/common/theme';
 import IntroModal from './common/IntroModal';
+import { RefreshPrompt } from './general/RefreshPrompt';
 import { useCustomComponent } from './custom';
 
 const PageContainer = styled.div`
@@ -102,6 +103,7 @@ const Layout = ({ children }: React.PropsWithChildren) => {
   )?.value;
 
   const introModalEnabled = !!(title && paragraph);
+  const showRefreshPrompt = instance.features.showRefreshPrompt;
 
   return (
     <>
@@ -122,6 +124,7 @@ const Layout = ({ children }: React.PropsWithChildren) => {
       <StyledSkipToContent href="#main">{t('skip-to-main-content')}</StyledSkipToContent>
       <NavComponent siteTitle={site.title} ownerName={site.owner} navItems={navItems} />
       <PageContainer>
+        {showRefreshPrompt && <RefreshPrompt />}
         <main className="main" id="main">
           {children}
         </main>

--- a/src/components/general/RefreshPrompt.tsx
+++ b/src/components/general/RefreshPrompt.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from 'react';
+import { ArrowClockwise, X } from 'react-bootstrap-icons';
+import { useApolloClient } from '@apollo/client';
+import { Toast, ToastBody, ToastHeader } from 'reactstrap';
+import styled from 'styled-components';
+
+import Button from '../common/Button';
+
+const DISABLE_REFRESH_PROMPT = 'hideRefreshPrompt';
+
+function getIsPromptDisabled() {
+  try {
+    return localStorage.getItem(DISABLE_REFRESH_PROMPT) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function storeDisableRefreshPrompt() {
+  try {
+    localStorage.setItem(DISABLE_REFRESH_PROMPT, 'true');
+  } catch {}
+}
+
+/**
+ * Determines if the toast to prompt the user to refresh the dashboard is visible.
+ * This is a quick-win, in future graphs should refresh automatically when data changes.
+ *
+ * The refresh prompt becomes visible in two scenarios:
+ *  1. When the user switches to another tab and returns, as they may
+ *     have edited data in the NetZeroPlanner Data Studio.
+ *  2. After ten minutes of inactivity, in case the user has switched
+ *     to another window to edit data without triggering a visibilitychange event.
+ *
+ * The hook also supports disabling the prompt "permanently" via localStorage.
+ */
+function useIsPromptVisible() {
+  const [isPromptVisible, setIsPromptVisible] = useState(false);
+  const [isPageVisible, setIsPageVisible] = useState(true);
+
+  const TEN_MINS = 10 * 60 * 1000;
+
+  function handleClose() {
+    setIsPromptVisible(false);
+  }
+
+  function handleDisablePrompt() {
+    handleClose();
+    storeDisableRefreshPrompt();
+  }
+
+  useEffect(() => {
+    const isDisabled = getIsPromptDisabled();
+
+    if (isDisabled || isPromptVisible) {
+      return;
+    }
+
+    const timeout = setTimeout(() => setIsPromptVisible(true), TEN_MINS);
+
+    function handleVisibilityChange() {
+      if (document.visibilityState === 'visible') {
+        if (!isPageVisible) {
+          clearTimeout(timeout);
+          setIsPromptVisible(true);
+        }
+
+        setIsPageVisible(true);
+      } else {
+        setIsPageVisible(false);
+      }
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      clearTimeout(timeout);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [isPromptVisible, isPageVisible]);
+
+  return {
+    isVisible: isPromptVisible,
+    handleDisable: handleDisablePrompt,
+    handleClose,
+  };
+}
+
+const StyledWrapper = styled.div<{ $isVisible: boolean }>`
+  position: fixed;
+  top: 0;
+  right: 0;
+  max-width: 500px;
+  display: ${({ $isVisible }) => ($isVisible ? 'block' : 'none')};
+  z-index: ${({ $isVisible }) => ($isVisible ? '100' : 'unset')};
+`;
+
+const StyledToast = styled(Toast)`
+  margin: ${({ theme }) => theme.spaces.s100};
+  background-color: ${({ theme }) => theme.cardBackground.primary};
+  display: block !important; // Support fade in transition
+`;
+
+const StyledActions = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  gap: 8px;
+`;
+
+export function RefreshPrompt() {
+  const { isVisible, handleDisable, handleClose } = useIsPromptVisible();
+  const apolloClient = useApolloClient();
+
+  function handleRefresh() {
+    apolloClient.refetchQueries({ include: ['GetPage'] });
+    handleClose();
+  }
+
+  return (
+    <StyledWrapper $isVisible={isVisible}>
+      <StyledToast isOpen={isVisible} fade transition={{ unmountOnExit: false }}>
+        <ToastHeader toggle={handleClose}>Refresh for the latest data</ToastHeader>
+        <ToastBody>
+          <p>
+            Updates may be available, click on the reload button or refresh the page to ensure you
+            have the latest content.
+          </p>
+          <StyledActions>
+            <Button size="sm" onClick={handleRefresh}>
+              <ArrowClockwise size={18} />
+              <span className="m-2">Reload</span>
+            </Button>
+            <Button size="sm" onClick={handleDisable}>
+              Don't show this again
+            </Button>
+          </StyledActions>
+        </ToastBody>
+      </StyledToast>
+    </StyledWrapper>
+  );
+}

--- a/src/queries/instance.ts
+++ b/src/queries/instance.ts
@@ -32,6 +32,7 @@ const GET_INSTANCE_CONTEXT = gql`
         baselineVisibleInGraphs
         showAccumulatedEffects
         showSignificantDigits
+        showRefreshPrompt
       }
       introContent {
         ... on StreamFieldInterface {

--- a/styles/default/main.scss
+++ b/styles/default/main.scss
@@ -51,7 +51,7 @@
 @import '~bootstrap/scss/progress';
 @import '~bootstrap/scss/list-group';
 @import '~bootstrap/scss/close';
-//@import "~bootstrap/scss/toasts";
+@import '~bootstrap/scss/toasts';
 //@import "~bootstrap/scss/modal";
 @import '~bootstrap/scss/tooltip';
 @import '~bootstrap/scss/popover';


### PR DESCRIPTION
Quick-win to inform users that the Paths dashboard doesn't update automatically. This is useful for NetZeroPlanner where users will tweak data and return to the dashboard to see the changes. Long term, charts should just listen to data changes and update automatically.

👮 Before deploying to production, the [corresponding backend](https://github.com/kausaltech/kausal-paths/pull/63) PR needs to be deployed (already in `main`)

https://github.com/user-attachments/assets/935a7cea-fced-421b-94db-663875415cb7

