### PR TITLE
Fix/widget visibility handling

### DIFF
--- a/src/components/general/ParameterWidget.tsx
+++ b/src/components/general/ParameterWidget.tsx
@@ -115,7 +115,7 @@ const NumberWidget = (props) => {
     handleChange({ parameterId: id, numberValue: newValues[0] });
   };
 
-  if (min === undefined || max === undefined) return null;
+  if (min == null || max == null) return null;
 
   const Reset = () =>
     defaultValue !== null ? (

--- a/src/components/general/ParameterWidget.tsx
+++ b/src/components/general/ParameterWidget.tsx
@@ -133,7 +133,7 @@ const NumberWidget = (props) => {
 
   return (
     <WidgetWrapper>
-      <div>{description || label || t('will_be_implemented')}</div>
+      <div>{description || label}</div>
       <RangeWrapper>
         <Range
           key="Base"

--- a/src/components/general/ParameterWidget.tsx
+++ b/src/components/general/ParameterWidget.tsx
@@ -43,6 +43,8 @@ const RangeValue = styled.div`
   min-width: 75px;
   margin-left: 1rem;
   line-height: 3;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const Thumb = styled.div<{ $dragged: boolean }>`
@@ -98,6 +100,7 @@ const NumberWidget = (props) => {
     handleChange,
     loading,
     description,
+    label,
     unit,
     step,
   } = props;
@@ -112,7 +115,7 @@ const NumberWidget = (props) => {
     handleChange({ parameterId: id, numberValue: newValues[0] });
   };
 
-  if (!min || !max) return null;
+  if (min === undefined || max === undefined) return null;
 
   const Reset = () =>
     defaultValue !== null ? (
@@ -121,9 +124,7 @@ const NumberWidget = (props) => {
         color="link"
         size="sm"
         outline
-        onClick={() =>
-          handleChange({ parameterId: id, numberValue: defaultValue })
-        }
+        onClick={() => handleChange({ parameterId: id, numberValue: defaultValue })}
         aria-label={t('reset-button')}
       >
         <Icon name="version" />
@@ -132,7 +133,7 @@ const NumberWidget = (props) => {
 
   return (
     <WidgetWrapper>
-      <div>{description}</div>
+      <div>{description || label || t('will_be_implemented')}</div>
       <RangeWrapper>
         <Range
           key="Base"
@@ -185,9 +186,7 @@ const NumberWidget = (props) => {
             />
           )}
         />
-        <RangeValue>
-          {`${values[0].toFixed(0)} ${unit?.htmlShort || ''}`}
-        </RangeValue>
+        <RangeValue>{`${values[0].toFixed(0)} ${unit?.htmlShort || ''}`}</RangeValue>
         {isCustomized ? <Reset /> : null}
       </RangeWrapper>
     </WidgetWrapper>
@@ -206,8 +205,7 @@ export const BoolWidget = (props: BoolWidgetProps) => {
   const { id, boolValue, isCustomized, isCustomizable } = parameter;
   const { t } = useTranslation();
 
-  const label =
-    parameter.label || parameter.description || t('will_be_implemented');
+  const label = parameter.label || parameter.description || t('will_be_implemented');
 
   return (
     <WidgetWrapper className="form-check form-switch">
@@ -218,9 +216,7 @@ export const BoolWidget = (props: BoolWidgetProps) => {
         id={id!}
         name={id!}
         checked={boolValue!}
-        onChange={() =>
-          handleChange({ parameterId: id!, boolValue: !boolValue })
-        }
+        onChange={() => handleChange({ parameterId: id!, boolValue: !boolValue })}
         disabled={!isCustomizable || loading}
         style={{ transform: 'scale(1.5)' }}
       />
@@ -241,16 +237,15 @@ const ParameterWidget = (props: ParameterWidgetProps) => {
   const { parameter } = props;
   const activeScenario = useReactiveVar(activeScenarioVar);
 
-  const [SetParameter, { loading: mutationLoading, error: mutationError }] =
-    useMutation<SetParameterMutation, SetParameterMutationVariables>(
-      SET_PARAMETER,
-      {
-        refetchQueries: 'active',
-        onCompleted: () => {
-          activeScenarioVar({ ...activeScenario });
-        },
-      }
-    );
+  const [SetParameter, { loading: mutationLoading, error: mutationError }] = useMutation<
+    SetParameterMutation,
+    SetParameterMutationVariables
+  >(SET_PARAMETER, {
+    refetchQueries: 'active',
+    onCompleted: () => {
+      activeScenarioVar({ ...activeScenario });
+    },
+  });
 
   const handleUserSelection = (evt) => {
     SetParameter({ variables: evt });
@@ -269,6 +264,7 @@ const ParameterWidget = (props: ParameterWidgetProps) => {
           loading={mutationLoading}
           isCustomized={parameter.isCustomized}
           description={parameter.description}
+          label={parameter.label}
           unit={parameter.unit}
           step={parameter.step}
         />

--- a/src/components/general/ParameterWidget.tsx
+++ b/src/components/general/ParameterWidget.tsx
@@ -137,7 +137,7 @@ const NumberWidget = (props) => {
       <RangeWrapper>
         <Range
           key="Base"
-          step={step ?? 1}
+          step={step && step <= max ? step : 1}
           min={min}
           max={max}
           values={values}

--- a/src/components/general/ParameterWidget.tsx
+++ b/src/components/general/ParameterWidget.tsx
@@ -237,7 +237,7 @@ const ParameterWidget = (props: ParameterWidgetProps) => {
   const { parameter } = props;
   const activeScenario = useReactiveVar(activeScenarioVar);
 
-  const [SetParameter, { loading: mutationLoading, error: mutationError }] = useMutation<
+  const [setParameter, { loading: mutationLoading, error: mutationError }] = useMutation<
     SetParameterMutation,
     SetParameterMutationVariables
   >(SET_PARAMETER, {
@@ -248,7 +248,7 @@ const ParameterWidget = (props: ParameterWidgetProps) => {
   });
 
   const handleUserSelection = (evt) => {
-    SetParameter({ variables: evt });
+    setParameter({ variables: evt });
   };
 
   switch (parameter.__typename) {
@@ -271,7 +271,7 @@ const ParameterWidget = (props: ParameterWidgetProps) => {
       );
 
     case 'StringParameterType':
-      return <div>String</div>;
+      return null;
 
     case 'BoolParameterType':
       return (


### PR DESCRIPTION
A bug fix: the parameter widget for actions was not displayed on the ActionList page and the individual action pages.
Asana - https://app.asana.com/0/1205310117865974/1208368029850926/f

* Updated the condition for `min` and `max` values to handle cases when they have valid `0`;
* Added fallback logic for `label` and `description`.
* Updated styles for `RangeValue` to prevent text from overflowing or breaking the layout.
* Removed the redundant placeholder "String" for StringParameterType;
* Added logic to set the step value to default 1 if the provided step value is larger than the max value.

<img width="1079" alt="Screen Shot 2024-10-22 at 08 58 03" src="https://github.com/user-attachments/assets/a33c8fd6-266c-41e7-a29f-2b81d3d5c1b9">
<img width="1208" alt="Screen Shot 2024-10-22 at 08 59 00" src="https://github.com/user-attachments/assets/9fda0f82-19ad-4736-8472-05391375f635">
