### PR TITLE
Fix mac graph overlapped by footer

### DIFF
--- a/src/components/graphs/MacGraph.tsx
+++ b/src/components/graphs/MacGraph.tsx
@@ -141,6 +141,7 @@ function MacGraph(props) {
 
   const layout = useMemo(
     () => ({
+      height: 450,
       barmode: 'relative',
       hoverlabel: {
         bgcolor: theme.themeColors.white,
@@ -175,14 +176,7 @@ function MacGraph(props) {
       paper_bgcolor: theme.themeColors.white,
       plot_bgcolor: theme.themeColors.white,
     }),
-    [
-      theme,
-      efficiencyName,
-      efficiencyUnit,
-      impactUnit,
-      impactName,
-      negativeSide,
-    ]
+    [theme, efficiencyName, efficiencyUnit, impactUnit, impactName, negativeSide]
   );
 
   const handleHover = useCallback(
@@ -247,10 +241,7 @@ function MacGraph(props) {
         <ActionDescription>
           <a href={`/actions/${actionIds[hoverId]}/`}>
             <HoverGroupTag color={data.colors[hoverId]}>
-              {
-                actionGroups.find((group) => group.id === data.groups[hoverId])
-                  ?.name
-              }
+              {actionGroups.find((group) => group.id === data.groups[hoverId])?.name}
             </HoverGroupTag>
             <h4>
               {data.actions[hoverId]} <Icon name="arrowRight" />
@@ -263,20 +254,14 @@ function MacGraph(props) {
                 <HoverValueValue>
                   {formatNumber(data.impact[hoverId], i18n.language)}
                 </HoverValueValue>
-                <HoverValueUnit
-                  dangerouslySetInnerHTML={{ __html: impactUnit }}
-                />
+                <HoverValueUnit dangerouslySetInnerHTML={{ __html: impactUnit }} />
               </HoverValue>
             </Col>
             <Col md={3} className="d-flex align-items-end">
               <HoverValue>
                 <HoverValueTitle>{costName}</HoverValueTitle>
-                <HoverValueValue>
-                  {formatNumber(data.cost[hoverId], i18n.language)}
-                </HoverValueValue>
-                <HoverValueUnit
-                  dangerouslySetInnerHTML={{ __html: costUnit }}
-                />
+                <HoverValueValue>{formatNumber(data.cost[hoverId], i18n.language)}</HoverValueValue>
+                <HoverValueUnit dangerouslySetInnerHTML={{ __html: costUnit }} />
               </HoverValue>
             </Col>
             <Col md={3} className="d-flex align-items-end">
@@ -285,9 +270,7 @@ function MacGraph(props) {
                 <HoverValueValue>
                   {formatNumber(data.efficiency[hoverId], i18n.language)}
                 </HoverValueValue>
-                <HoverValueUnit
-                  dangerouslySetInnerHTML={{ __html: efficiencyUnit }}
-                />
+                <HoverValueUnit dangerouslySetInnerHTML={{ __html: efficiencyUnit }} />
               </HoverValue>
             </Col>
           </Row>

--- a/src/components/graphs/MacGraph.tsx
+++ b/src/components/graphs/MacGraph.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useTranslation } from 'next-i18next';
 import styled, { useTheme } from 'styled-components';
 import dynamic from 'next/dynamic';
@@ -9,7 +9,6 @@ import { t } from 'i18next';
 const Plot = dynamic(() => import('components/graphs/Plot'), { ssr: false });
 
 const GraphContainer = styled.div`
-  margin-bottom: 3rem;
   .js-plotly-plot {
     margin-bottom: 1rem;
   }
@@ -74,13 +73,6 @@ function MacGraph(props) {
   } = props;
   const theme = useTheme();
   const { i18n, t } = useTranslation();
-  const graphRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (graphRef.current) {
-      graphRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }
-  }, [data]);
 
   const barHoverColor = theme.graphColors.green090;
 
@@ -183,7 +175,14 @@ function MacGraph(props) {
       paper_bgcolor: theme.themeColors.white,
       plot_bgcolor: theme.themeColors.white,
     }),
-    [theme, efficiencyName, efficiencyUnit, impactUnit, impactName, negativeSide]
+    [
+      theme,
+      efficiencyName,
+      efficiencyUnit,
+      impactUnit,
+      impactName,
+      negativeSide,
+    ]
   );
 
   const handleHover = useCallback(
@@ -242,13 +241,16 @@ function MacGraph(props) {
   );
 
   return (
-    <GraphContainer ref={graphRef}>
+    <GraphContainer>
       {plot}
       {hoverId !== null && (
         <ActionDescription>
           <a href={`/actions/${actionIds[hoverId]}/`}>
             <HoverGroupTag color={data.colors[hoverId]}>
-              {actionGroups.find((group) => group.id === data.groups[hoverId])?.name}
+              {
+                actionGroups.find((group) => group.id === data.groups[hoverId])
+                  ?.name
+              }
             </HoverGroupTag>
             <h4>
               {data.actions[hoverId]} <Icon name="arrowRight" />
@@ -261,14 +263,20 @@ function MacGraph(props) {
                 <HoverValueValue>
                   {formatNumber(data.impact[hoverId], i18n.language)}
                 </HoverValueValue>
-                <HoverValueUnit dangerouslySetInnerHTML={{ __html: impactUnit }} />
+                <HoverValueUnit
+                  dangerouslySetInnerHTML={{ __html: impactUnit }}
+                />
               </HoverValue>
             </Col>
             <Col md={3} className="d-flex align-items-end">
               <HoverValue>
                 <HoverValueTitle>{costName}</HoverValueTitle>
-                <HoverValueValue>{formatNumber(data.cost[hoverId], i18n.language)}</HoverValueValue>
-                <HoverValueUnit dangerouslySetInnerHTML={{ __html: costUnit }} />
+                <HoverValueValue>
+                  {formatNumber(data.cost[hoverId], i18n.language)}
+                </HoverValueValue>
+                <HoverValueUnit
+                  dangerouslySetInnerHTML={{ __html: costUnit }}
+                />
               </HoverValue>
             </Col>
             <Col md={3} className="d-flex align-items-end">
@@ -277,7 +285,9 @@ function MacGraph(props) {
                 <HoverValueValue>
                   {formatNumber(data.efficiency[hoverId], i18n.language)}
                 </HoverValueValue>
-                <HoverValueUnit dangerouslySetInnerHTML={{ __html: efficiencyUnit }} />
+                <HoverValueUnit
+                  dangerouslySetInnerHTML={{ __html: efficiencyUnit }}
+                />
               </HoverValue>
             </Col>
           </Row>

--- a/src/components/graphs/MacGraph.tsx
+++ b/src/components/graphs/MacGraph.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useTranslation } from 'next-i18next';
 import styled, { useTheme } from 'styled-components';
 import dynamic from 'next/dynamic';
@@ -9,6 +9,7 @@ import { t } from 'i18next';
 const Plot = dynamic(() => import('components/graphs/Plot'), { ssr: false });
 
 const GraphContainer = styled.div`
+  margin-bottom: 3rem;
   .js-plotly-plot {
     margin-bottom: 1rem;
   }
@@ -73,6 +74,13 @@ function MacGraph(props) {
   } = props;
   const theme = useTheme();
   const { i18n, t } = useTranslation();
+  const graphRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (graphRef.current) {
+      graphRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [data]);
 
   const barHoverColor = theme.graphColors.green090;
 
@@ -175,14 +183,7 @@ function MacGraph(props) {
       paper_bgcolor: theme.themeColors.white,
       plot_bgcolor: theme.themeColors.white,
     }),
-    [
-      theme,
-      efficiencyName,
-      efficiencyUnit,
-      impactUnit,
-      impactName,
-      negativeSide,
-    ]
+    [theme, efficiencyName, efficiencyUnit, impactUnit, impactName, negativeSide]
   );
 
   const handleHover = useCallback(
@@ -241,16 +242,13 @@ function MacGraph(props) {
   );
 
   return (
-    <GraphContainer>
+    <GraphContainer ref={graphRef}>
       {plot}
       {hoverId !== null && (
         <ActionDescription>
           <a href={`/actions/${actionIds[hoverId]}/`}>
             <HoverGroupTag color={data.colors[hoverId]}>
-              {
-                actionGroups.find((group) => group.id === data.groups[hoverId])
-                  ?.name
-              }
+              {actionGroups.find((group) => group.id === data.groups[hoverId])?.name}
             </HoverGroupTag>
             <h4>
               {data.actions[hoverId]} <Icon name="arrowRight" />
@@ -263,20 +261,14 @@ function MacGraph(props) {
                 <HoverValueValue>
                   {formatNumber(data.impact[hoverId], i18n.language)}
                 </HoverValueValue>
-                <HoverValueUnit
-                  dangerouslySetInnerHTML={{ __html: impactUnit }}
-                />
+                <HoverValueUnit dangerouslySetInnerHTML={{ __html: impactUnit }} />
               </HoverValue>
             </Col>
             <Col md={3} className="d-flex align-items-end">
               <HoverValue>
                 <HoverValueTitle>{costName}</HoverValueTitle>
-                <HoverValueValue>
-                  {formatNumber(data.cost[hoverId], i18n.language)}
-                </HoverValueValue>
-                <HoverValueUnit
-                  dangerouslySetInnerHTML={{ __html: costUnit }}
-                />
+                <HoverValueValue>{formatNumber(data.cost[hoverId], i18n.language)}</HoverValueValue>
+                <HoverValueUnit dangerouslySetInnerHTML={{ __html: costUnit }} />
               </HoverValue>
             </Col>
             <Col md={3} className="d-flex align-items-end">
@@ -285,9 +277,7 @@ function MacGraph(props) {
                 <HoverValueValue>
                   {formatNumber(data.efficiency[hoverId], i18n.language)}
                 </HoverValueValue>
-                <HoverValueUnit
-                  dangerouslySetInnerHTML={{ __html: efficiencyUnit }}
-                />
+                <HoverValueUnit dangerouslySetInnerHTML={{ __html: efficiencyUnit }} />
               </HoverValue>
             </Col>
           </Row>

--- a/src/components/pages/ActionListPage.tsx
+++ b/src/components/pages/ActionListPage.tsx
@@ -210,14 +210,6 @@ function ActionListPage({ page }: ActionListPageProps) {
   const [activeEfficiency, setActiveEfficiency] = useState<number>(0);
   const [actionGroup, setActionGroup] = useState<'ALL_ACTIONS' | string>('ALL_ACTIONS');
 
-  // Different default view if we have action efficiency pairs
-  useEffect(() => {
-    if (areActionsLoading === false && data && hasEfficiency) {
-      setListType('mac');
-      setSortBy(sortOptions.find((option) => option.key === 'CUM_EFFICIENCY') ?? sortOptions[0]);
-    }
-  }, [areActionsLoading, data, hasEfficiency]);
-
   const filteredActions = (data?.actions || []).filter(
     (action) =>
       !page.showOnlyMunicipalActions ||


### PR DESCRIPTION
Efficiency (Mac) graph is overlapped by footer on initial page load - Asana https://app.asana.com/0/1206017643443542/1208685262451477/f

* Added fixed height (450px) to the graph layout to prevent overlap;
* Removed the `useEffect` hook that conditionally displayed the MAC graph first for efficiency pairs.

https://github.com/user-attachments/assets/019e8709-584a-4d7c-b51e-133c52349ed0

