### PR TITLE
Fix e2e tests

### DIFF
--- a/.github/workflows/e2e-image.yaml
+++ b/.github/workflows/e2e-image.yaml
@@ -6,7 +6,7 @@ on:
         description: 'Comma separated list of instance identifiers'
         required: false
         type: string
-        default: 'sunnydale,espoo,zuerich'
+        default: 'sunnydale,espoo' #,zuerich'
       image:
         description: 'Image (incl. repo, path, tag) to test'
         required: true

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -4,7 +4,7 @@
   "description": "End-to-end tests for Kausal Paths UI",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "playwright test --workers 2"
   },
   "author": "",
   "license": "AGPL-3.0-or-later",

--- a/e2e-tests/tests/basic.spec.ts
+++ b/e2e-tests/tests/basic.spec.ts
@@ -77,6 +77,7 @@ const testInstance = (instanceId: string) =>
       */
       // Test direct URL navigation
       await page.goto(`${ctx.baseURL}${listItem.urlPath}`);
+      await expect(page).toHaveURL(`${ctx.baseURL}${listItem.urlPath}`, { timeout: 3000 }); // Fix NS_BINDING_ABORTED error in Firefox
       await ctx.checkMeta(page);
       await ctx.waitForLoaded(page);
       await expect


### PR DESCRIPTION
- Remove Z from list of plans to test against
- Fix a NS_BINDING_ABORTED error in Firefox by waiting for the navigation to complete