### PR TITLE
Conditionally hide SettingsPanelFull

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -24,9 +24,9 @@ const PageContainer = styled.div`
   }
 `;
 
-const FooterContainer = styled.footer`
+const FooterContainer = styled.footer<{ isSettingsPanelHidden: boolean }>`
   background-color: ${(props) => props.theme.themeColors.black};
-  padding-bottom: 7rem;
+  padding-bottom: ${({ isSettingsPanelHidden }) => (isSettingsPanelHidden ? '0' : '7rem')};
 `;
 
 const StyledSkipToContent = styled.a`
@@ -92,6 +92,8 @@ const Layout = ({ children }: React.PropsWithChildren) => {
 
   const instance = useInstance();
 
+  const isSettingsPanelHidden = !!instance.features?.hideNodeDetails;
+
   const title = instance.introContent?.find(
     (block): block is { __typename: 'RichTextBlock'; field: string; value: string } =>
       block.__typename === 'RichTextBlock' && block.field === 'title'
@@ -129,7 +131,7 @@ const Layout = ({ children }: React.PropsWithChildren) => {
           {children}
         </main>
       </PageContainer>
-      <FooterContainer>
+      <FooterContainer isSettingsPanelHidden={isSettingsPanelHidden}>
         <FooterComponent />
       </FooterContainer>
       {introModalEnabled && <IntroModal title={title} paragraph={paragraph} />}

--- a/src/components/pages/OutcomePage.tsx
+++ b/src/components/pages/OutcomePage.tsx
@@ -97,6 +97,7 @@ export default function OutcomePage(props: OutcomePageProps) {
 
   const pageLeadTitle = page.leadTitle || instance.leadTitle;
   const pageLeadParagraph = page.leadParagraph || instance.leadParagraph;
+  const showSettingsPanel = !instance.features?.hideNodeDetails;
 
   return (
     <>
@@ -130,7 +131,7 @@ export default function OutcomePage(props: OutcomePageProps) {
           ))}
         </>
       </PageHero>
-      <SettingsPanelFull />
+      {showSettingsPanel && <SettingsPanelFull />}
     </>
   );
 }


### PR DESCRIPTION
Asana https://app.asana.com/0/1206017643443542/1209105609937758/f

* Added feature flag to conditionally hide `SettingsPanelFull` in `OutcomePage` for NZC instances
* Fixed the side-effect visual bug (a black block appears at the bottom of the page when the panel is hidden):
<img width="1417" alt="Screenshot 2025-01-17 at 12 18 57" src="https://github.com/user-attachments/assets/725a699d-ee94-46ad-9206-3b63a0c88c13" />
