### PR TITLE
Ensure the active scenario is used when querying metricDim with the progress tracking scenario

### DIFF
--- a/src/components/general/DimensionalNodePlot.tsx
+++ b/src/components/general/DimensionalNodePlot.tsx
@@ -3,7 +3,7 @@ import dynamic from 'next/dynamic';
 
 import { useReactiveVar } from '@apollo/client';
 import { type DimensionalNodeMetricFragment } from 'common/__generated__/graphql';
-import { activeGoalVar } from 'common/cache';
+import { activeGoalVar, activeScenarioVar } from 'common/cache';
 import { genColorsFromTheme, setUniqueColors } from 'common/colors';
 import { type InstanceGoal, useInstance, useFeatures } from 'common/instance';
 import { getRange } from 'common/preprocess';
@@ -162,6 +162,7 @@ export default function DimensionalNodePlot({
 }: DimensionalNodePlotProps) {
   const { t } = useTranslation();
   const activeGoal = useReactiveVar(activeGoalVar);
+  const activeScenarioId = useReactiveVar(activeScenarioVar)?.id ?? undefined;
   const theme = useTheme();
   const site = useContext(SiteContext);
   const instance = useInstance();
@@ -169,13 +170,13 @@ export default function DimensionalNodePlot({
   const observedEmissionsLabel = t('observed-emissions');
 
   const metrics = useMemo(() => {
-    const defaultMetric = new DimensionalMetric(metric);
+    const defaultMetric = new DimensionalMetric(metric, activeScenarioId);
 
     return {
       default: defaultMetric,
       progress: hasProgressTracking ? new DimensionalMetric(metric, 'progress_tracking') : null,
     };
-  }, [metric, hasProgressTracking]);
+  }, [metric, hasProgressTracking, activeScenarioId]);
 
   const cube = metrics.default;
 


### PR DESCRIPTION
⚠️ Joe to check next whether this is still necessary next week! The workaround might be good enough

Original [report in Slack](https://kausaltech.slack.com/archives/C029WNCMF0T/p1737108565419949) 🎟️ 


Previously, for NZC instances where progress tracking is used, we always fetched the `'default'` and `'progress_tracking'` scenario. This change replaces `'default'` with the id of the selected scenario.

This ensures the correct data is shown when switching scenarios.