### PR TITLE
Fix/translate watch link

### DIFF
--- a/public/locales/es-US/common.json
+++ b/public/locales/es-US/common.json
@@ -110,5 +110,8 @@
   "ktco2-e": "kt CO<sub>2</sub>eq/a",
   "do-not-show-again": "No mostrar de nuevo",
   "close": "Cerrar",
-  "coming-soon": "Próximamente"
+  "coming-soon": "Próximamente",
+  "watch": {
+    "longmont": "Indicadores de Longmont"
+  }
 }

--- a/src/components/common/GlobalNav.tsx
+++ b/src/components/common/GlobalNav.tsx
@@ -295,12 +295,23 @@ export type GlobalNavProps = {
 };
 
 function GlobalNav(props: React.PropsWithChildren<GlobalNavProps>) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const site = useContext(SiteContext);
   const theme = useTheme();
   const [navIsFixed, setnavIsFixed] = useState(false);
   const [isOpen, toggleOpen] = useState(false);
   const { siteTitle, ownerName, navItems, sticky } = props;
+  const instanceId = site.instanceId || site.instanceContext?.id || 'default';
+
+  const watchLinkTitle = site.watchLink
+    ? t(`watch.${site.instanceId}`, { defaultValue: site.watchLink.title })
+    : null;
+
+  const watchLinkUrl = site.watchLink
+    ? i18n.language.startsWith('es-US') || i18n.language === 'es-US'
+      ? `${site.watchLink.url}/es-US`
+      : site.watchLink.url
+    : '';
 
   const orgLogo = useMemo(() => {
     const url = getThemeStaticURL(theme.themeLogoUrl);
@@ -314,10 +325,6 @@ function GlobalNav(props: React.PropsWithChildren<GlobalNavProps>) {
       />
     );
   }, [theme.themeLogoUrl, ownerName, siteTitle, t]);
-
-  const translatedWatchLinkTitle = site.watchLink
-    ? t(`watch.${site.instanceId}`, { defaultValue: site.watchLink.title })
-    : null;
 
   if (sticky) {
     useScrollPosition(
@@ -403,11 +410,9 @@ function GlobalNav(props: React.PropsWithChildren<GlobalNavProps>) {
             <Nav navbar>
               <NavItem>
                 <NavLink>
-                  <Link href={site.watchLink.url}>
+                  <Link href={watchLinkUrl}>
                     <a>
-                      <NavHighlighter className="highlighter">
-                        {translatedWatchLinkTitle}
-                      </NavHighlighter>
+                      <NavHighlighter className="highlighter">{watchLinkTitle}</NavHighlighter>
                     </a>
                   </Link>
                 </NavLink>

--- a/src/components/common/GlobalNav.tsx
+++ b/src/components/common/GlobalNav.tsx
@@ -315,6 +315,10 @@ function GlobalNav(props: React.PropsWithChildren<GlobalNavProps>) {
     );
   }, [theme.themeLogoUrl, ownerName, siteTitle, t]);
 
+  const translatedWatchLinkTitle = site.watchLink
+    ? t(`watch.${site.instanceId}`, { defaultValue: site.watchLink.title })
+    : null;
+
   if (sticky) {
     useScrollPosition(
       ({ prevPos, currPos }) => {
@@ -402,7 +406,7 @@ function GlobalNav(props: React.PropsWithChildren<GlobalNavProps>) {
                   <Link href={site.watchLink.url}>
                     <a>
                       <NavHighlighter className="highlighter">
-                        {site.watchLink.title}
+                        {translatedWatchLinkTitle}
                       </NavHighlighter>
                     </a>
                   </Link>

--- a/src/context/site.tsx
+++ b/src/context/site.tsx
@@ -35,10 +35,6 @@ export type SiteContextType = {
   availableNormalizations: GetInstanceContextQuery['availableNormalizations'];
   parameters: GetInstanceContextQuery['parameters'];
   menuPages: GetInstanceContextQuery['menuPages'];
-  watchLink?: {
-    title: string;
-    url: string;
-  } | null;
 };
 
 const SiteContext = React.createContext<SiteContextType>(null!);

--- a/src/context/site.tsx
+++ b/src/context/site.tsx
@@ -11,6 +11,7 @@ export type SiteI18nConfig = {
 };
 
 export type SiteContextType = {
+  instanceId?: string;
   title: string;
   apolloConfig: {
     instanceHostname: string;

--- a/src/context/site.tsx
+++ b/src/context/site.tsx
@@ -35,6 +35,10 @@ export type SiteContextType = {
   availableNormalizations: GetInstanceContextQuery['availableNormalizations'];
   parameters: GetInstanceContextQuery['parameters'];
   menuPages: GetInstanceContextQuery['menuPages'];
+  watchLink?: {
+    title: string;
+    url: string;
+  } | null;
 };
 
 const SiteContext = React.createContext<SiteContextType>(null!);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -110,6 +110,7 @@ const defaultSiteContext: { [key: string]: SiteContextType } = {
     },
   },
   longmont: {
+    instanceId: 'longmont',
     watchLink: {
       title: 'Longmont Indicators',
       url: 'https://indicators.longmontcolorado.gov',


### PR DESCRIPTION
A customer request: The NavBar's Watch link title is not translated for the Spanish version and language context is lost when redirected to Watch. Asana - https://app.asana.com/0/1206017643443542/1209285235193134.

* Added Spanish translation support for `watchLink`;
* Applied redirection based on selected language (`es-US`).