### PR TITLE
Display Measured years budge for NZP

### DIFF
--- a/src/components/common/ScenarioBadge.tsx
+++ b/src/components/common/ScenarioBadge.tsx
@@ -32,11 +32,16 @@ type ScenarioBadgeProps = {
 const ScenarioBadge = (props: ScenarioBadgeProps) => {
   const { children, startYear, endYear } = props;
 
+  const formattedYears =
+    startYear && endYear
+      ? startYear === endYear
+        ? `${startYear}`
+        : `${startYear} - ${endYear}`
+      : '';
+
   return (
     <StyledBadge>
-      {startYear && endYear && (
-        <BadgeYears>{`${startYear} - ${endYear}`}: </BadgeYears>
-      )}
+      {formattedYears && <BadgeYears>{formattedYears}: </BadgeYears>}
       {children}
     </StyledBadge>
   );

--- a/src/components/general/OutcomeNodeContent.tsx
+++ b/src/components/general/OutcomeNodeContent.tsx
@@ -208,7 +208,7 @@ const OutcomeNodeContent = ({
               )}
             </h4>
             <CardSetDescriptionDetails>
-              {startYear < lastMeasuredYear && (
+              {startYear <= lastMeasuredYear && (
                 <ScenarioBadge startYear={startYear} endYear={lastMeasuredYear}>
                   {t('table-historical')}
                 </ScenarioBadge>


### PR DESCRIPTION
Display Measured year scenario budge on OutcomeNode for NZP plans.
Asana https://app.asana.com/0/1206017643443542/1209329031547612

* Updated `OutcomeNodeContent` logic to display the "Measured" budge when `startYear = lastMeasuredYear`;
* Updated `ScenarioBadge` to handle single year display on the budge.

<img width="1358" alt="Screenshot 2025-02-10 at 13 10 14" src="https://github.com/user-attachments/assets/838dce57-ef6b-4918-960d-32b5422c35ab" />
