### PR TITLE
Fix refresh prompt not refetching driver visualisations

### DIFF
--- a/src/components/general/RefreshPrompt.tsx
+++ b/src/components/general/RefreshPrompt.tsx
@@ -91,7 +91,7 @@ const StyledWrapper = styled.div<{ $isVisible: boolean }>`
   right: 0;
   max-width: 500px;
   display: ${({ $isVisible }) => ($isVisible ? 'block' : 'none')};
-  z-index: ${({ $isVisible }) => ($isVisible ? '100' : 'unset')};
+  z-index: ${({ $isVisible }) => ($isVisible ? '1100' : 'unset')};
 `;
 
 const StyledToast = styled(Toast)`
@@ -112,7 +112,7 @@ export function RefreshPrompt() {
   const apolloClient = useApolloClient();
 
   function handleRefresh() {
-    apolloClient.refetchQueries({ include: ['GetPage'] });
+    apolloClient.refetchQueries({ include: ['GetPage', 'GetNodeVisualizations'] });
     handleClose();
   }
 
@@ -131,7 +131,7 @@ export function RefreshPrompt() {
               <span className="m-2">Reload</span>
             </Button>
             <Button size="sm" onClick={handleDisable}>
-              Don't show this again
+              Don&apos;t show this again
             </Button>
           </StyledActions>
         </ToastBody>

--- a/src/components/general/progress-tracking/ProgressDriversVisualization.tsx
+++ b/src/components/general/progress-tracking/ProgressDriversVisualization.tsx
@@ -316,7 +316,7 @@ export function ProgressDriversVisualization({ metric, desiredOutcome, title }: 
       ],
     };
     return option;
-  }, [metric, theme, activeGoal, site.minYear, site.scenarios, desiredOutcome]);
+  }, [t, metric, theme, activeGoal, site.minYear, site.scenarios, desiredOutcome]);
 
   if (!chartData) {
     return null;

--- a/src/components/general/progress-tracking/ProgressDriversWrapper.tsx
+++ b/src/components/general/progress-tracking/ProgressDriversWrapper.tsx
@@ -51,6 +51,7 @@ export function ProgressDriversWrapper({ nodeId }: Props) {
 
   const { loading, error, data } = useQuery<GetNodeVisualizationsQuery>(GET_NODE_VISUALIZATIONS, {
     variables: { nodeId, scenarios: ['default', 'progress_tracking'] },
+    notifyOnNetworkStatusChange: true,
   });
 
   if (loading) {


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/1/1201243246741462/project/1205309956497857/task/1209944911729007?focus=true)

Previously, when clicking the "Refresh" button on the refresh data prompt, the node visualisations graph did not load the latest data. This ensures `GetNodeVisualizations` is refetched and the loading indicator is displayed. 

Also ensure the refresh prompt is displayed above the sidebar.