### PR TITLE
Fix refresh prompt not getting latest progress tracker years

### DIFF
--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -1564,7 +1564,10 @@ export type GetNodeVisualizationsQueryVariables = Exact<{
 
 
 export type GetNodeVisualizationsQuery = (
-  { node: (
+  { scenarios: Array<(
+    { id: string, isActive: boolean, isDefault: boolean, name: string, actualHistoricalYears: Array<number> | null, kind: ScenarioKind | null }
+    & { __typename: 'ScenarioType' }
+  )>, node: (
     { id: string, metricDim: (
       { id: string, name: string, stackable: boolean, forecastFrom: number | null, years: Array<number>, values: Array<number>, dimensions: Array<(
         { id: string, label: string, originalId: string | null, helpText: string | null, categories: Array<(

--- a/src/components/common/GlobalNav.tsx
+++ b/src/components/common/GlobalNav.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { useScrollPosition } from '@n8tb1t/use-scroll-position';
 import { Link } from 'common/links';
@@ -8,7 +8,7 @@ import NavDropdown, {
   type NavDropdownProps,
 } from 'components/common/NavDropdown';
 import LanguageSelector from 'components/general/LanguageSelector';
-import SiteContext from 'context/site';
+import { useSite } from 'context/site';
 import { useTranslation } from 'next-i18next';
 import { transparentize } from 'polished';
 import SVG from 'react-inlinesvg';
@@ -296,7 +296,7 @@ export type GlobalNavProps = {
 
 function GlobalNav(props: React.PropsWithChildren<GlobalNavProps>) {
   const { t, i18n } = useTranslation();
-  const site = useContext(SiteContext);
+  const site = useSite();
   const theme = useTheme();
   const [navIsFixed, setnavIsFixed] = useState(false);
   const [isOpen, toggleOpen] = useState(false);

--- a/src/components/custom/zurich/Footer.tsx
+++ b/src/components/custom/zurich/Footer.tsx
@@ -21,12 +21,6 @@ const StyledFooter = styled.div`
 `;
 
 const Footer = (props) => {
-  const { t } = useTranslation();
-  const site = useContext(SiteContext);
-  const theme = useTheme();
-  const [navIsFixed, setnavIsFixed] = useState(false);
-  const [isOpen, toggleOpen] = useState(false);
-
   return (
     <stzh-footer variant="egov" className="hydrated">
       <StyledFooter className="stzh-footer">

--- a/src/components/custom/zurich/GlobalNav.tsx
+++ b/src/components/custom/zurich/GlobalNav.tsx
@@ -1,10 +1,10 @@
-import React, { useContext, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import Head from 'next/head';
 
 import { Link } from 'common/links';
 import NavDropdown, { type NavDropdownProps } from 'components/common/NavDropdown';
 import LanguageSelector from 'components/general/LanguageSelector';
-import SiteContext from 'context/site';
+import { useSite } from 'context/site';
 import { useTranslation } from 'next-i18next';
 import { transparentize } from 'polished';
 import * as Icon from 'react-bootstrap-icons';
@@ -262,7 +262,7 @@ function DropdownList(props: NavDropdownProps & { parentName: string }) {
 
 function GlobalNav(props: GlobalNavProps) {
   const { t } = useTranslation();
-  const site = useContext(SiteContext);
+  const site = useSite();
   const theme = useTheme();
   const [isOpen, toggleOpen] = useState(false);
   const { siteTitle, ownerName, navItems, sticky } = props;

--- a/src/components/general/DimensionalNodePlot.tsx
+++ b/src/components/general/DimensionalNodePlot.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 
 import { useReactiveVar } from '@apollo/client';
@@ -9,7 +9,7 @@ import { type InstanceGoal, useInstance, useFeatures } from 'common/instance';
 import { getRange } from 'common/preprocess';
 import Icon from 'components/common/icon';
 import SelectDropdown from 'components/common/SelectDropdown';
-import SiteContext from 'context/site';
+import { useSite } from 'context/site';
 import {
   DimensionalMetric,
   type MetricCategoryValues,
@@ -163,7 +163,7 @@ export default function DimensionalNodePlot({
   const { t } = useTranslation();
   const activeGoal = useReactiveVar(activeGoalVar);
   const theme = useTheme();
-  const site = useContext(SiteContext);
+  const site = useSite();
   const instance = useInstance();
   const hasProgressTracking = metricHasProgressTrackingScenario(metric, site.scenarios);
   const observedEmissionsLabel = t('observed-emissions');

--- a/src/components/general/progress-tracking/ProgressDriversVisualization.tsx
+++ b/src/components/general/progress-tracking/ProgressDriversVisualization.tsx
@@ -140,7 +140,10 @@ export function ProgressDriversVisualization({ metric, desiredOutcome, title }: 
       progressData: number[];
     };
 
-    let progressYears = getProgressTrackingScenario(site.scenarios)?.actualHistoricalYears ?? [];
+    let progressYears = [
+      ...(getProgressTrackingScenario(site.scenarios)?.actualHistoricalYears ?? []),
+    ];
+
     if (metric.measureDatapointYears.length) {
       progressYears = progressYears.filter((year) => metric.measureDatapointYears.includes(year));
     }
@@ -174,7 +177,7 @@ export function ProgressDriversVisualization({ metric, desiredOutcome, title }: 
           defaultValue: allDefaultData[i] ?? null,
           progressValue:
             year !== site.minYear && progressYears.includes(year)
-              ? (allProgressData[i] ?? null)
+              ? allProgressData[i] ?? null
               : null,
         };
       })

--- a/src/context/site.tsx
+++ b/src/context/site.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, type Dispatch, type SetStateAction } from 'react';
 
 import type { GetInstanceContextQuery } from 'common/__generated__/graphql';
 
@@ -37,9 +37,27 @@ export type SiteContextType = {
   menuPages: GetInstanceContextQuery['menuPages'];
 };
 
-const SiteContext = React.createContext<SiteContextType>(null!);
+export type SiteContextWithSetterType = [
+  SiteContextType,
+  Dispatch<SetStateAction<SiteContextType>>,
+];
 
+const SiteContext = React.createContext<SiteContextWithSetterType>(null!);
+
+/**
+ * @deprecated Use useSiteWithSetter instead
+ */
 export const useSite = () => {
+  const [siteContext] = useContext(SiteContext);
+
+  return siteContext;
+};
+
+/**
+ * For legacy reasons, expose the full site context with context value and
+ * setter in a separate hook. In future we could migrate all uses of useSite to this.
+ */
+export const useSiteWithSetter = () => {
   return useContext(SiteContext);
 };
 

--- a/src/context/site.tsx
+++ b/src/context/site.tsx
@@ -48,9 +48,13 @@ const SiteContext = React.createContext<SiteContextWithSetterType>(null!);
  * @deprecated Use useSiteWithSetter instead
  */
 export const useSite = () => {
-  const [siteContext] = useContext(SiteContext);
+  const context = useContext(SiteContext);
 
-  return siteContext;
+  if (!context) {
+    return null;
+  }
+
+  return context[0];
 };
 
 /**

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import App, { type AppContext, type AppProps } from 'next/app';
 
 import { ApolloClient, ApolloProvider, isApolloError } from '@apollo/client';
@@ -172,9 +172,17 @@ export type PathsAppProps = AppProps & {
 };
 
 function PathsApp(props: PathsAppProps) {
-  const { Component, pageProps, siteContext, instanceContext, themeProps } = props;
+  const {
+    Component,
+    pageProps,
+    siteContext: initialSiteContext,
+    instanceContext,
+    themeProps,
+  } = props;
   const isProd = deploymentType === 'production';
+  const [siteContext, setSiteContext] = useState<SiteContextType>(initialSiteContext);
   const { i18n } = useTranslation();
+
   // FIXME: Remove this when possible; it's not safe for async contexts
   numbro.setLanguage(
     i18n.language,
@@ -215,7 +223,7 @@ function PathsApp(props: PathsAppProps) {
   const apolloClient = initializeApollo(null, siteContext.apolloConfig);
 
   return (
-    <SiteContext.Provider value={siteContext}>
+    <SiteContext.Provider value={[siteContext, setSiteContext]}>
       <InstanceContext.Provider value={instanceContext}>
         <ApolloProvider client={apolloClient}>
           <ThemeProvider theme={themeProps}>

--- a/src/queries/getNodeVisualizations.ts
+++ b/src/queries/getNodeVisualizations.ts
@@ -1,12 +1,18 @@
 import { gql } from '@apollo/client';
 import visualizationEntryFragment from './visualizationEntryFragment';
 import { DimensionalMetric } from '@/data/metric';
+import { scenarioFragment } from './instance';
 
 export const GET_NODE_VISUALIZATIONS = gql`
   ${visualizationEntryFragment}
   ${DimensionalMetric.fragment}
+  ${scenarioFragment}
 
   query GetNodeVisualizations($nodeId: ID!) {
+    # Ensure we get the latest actualHistoricalYears for the progress tracking scenario
+    scenarios {
+      ...ScenarioFragment
+    }
     node(id: $nodeId) {
       id
       metricDim(withScenarios: ["default", "progress_tracking"]) {


### PR DESCRIPTION
Previously, when clicking the refresh prompt on NetZeroPlanner Paths instances, we did not fetch the latest `scenarios` which includes the progress tracking scenario's `actualHistoricalYears`. `actualHistoricalYears` tells the UI which years the user has entered observed data for in NetZeroPlanner, and because this data was stale, we failed to show a `x` on progress driver graphs marking observed data.

This change allows us to partially update the site context by adding a `setState` handler to `SiteContext`.

To test:
1. Go to Arlandria's Paths page: http://arlandria-cap-2030.localhost:3000/
2. Open the observed emissions details by clicking "Off track"
3. Click electricity emissions and scroll to the total energy demand driver — there should be a year without any data at all, it should not have a `x`
4. Open https://netzero.kausal.tech/additional-data and select Arlandria
5. Enter a value for the year with no `x` mark under Electricity → Total electricity demand within city boundaries
6. Go back to the Paths tab and click "Refresh" on the refresh prompt
7. You should see an updated graph with an `x` mark and the value you entered in step 5.

<img width="371" alt="Screenshot 2025-06-10 at 14 05 32" src="https://github.com/user-attachments/assets/5f679fa0-3459-4c91-8599-b34d96fb9e4a" />

<img width="815" alt="Screenshot 2025-06-10 at 14 05 38" src="https://github.com/user-attachments/assets/c2c624df-e581-4f1c-83c4-7aa966d5a019" />

<img width="1289" alt="Screenshot 2025-06-10 at 14 05 45" src="https://github.com/user-attachments/assets/251e45f6-e2b5-42d6-906e-8736d76b682e" />