### PR TITLE
Add tooltip context for NZC

### DIFF
--- a/src/components/common/PopoverTip.tsx
+++ b/src/components/common/PopoverTip.tsx
@@ -1,7 +1,18 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
+import styled, { createGlobalStyle } from 'styled-components';
 import { useTranslation } from 'common/i18n';
 import { Button, Tooltip } from 'reactstrap';
+
+// Fixes an issue where the tooltip initially renders below the parent element
+const GlobalStyles = createGlobalStyle`
+  .tooltip-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 400px;
+    z-index: 1040;
+  }
+`;
 
 const InfoButton = styled(Button)`
   padding: 0 0.5rem 0.1rem;
@@ -9,9 +20,7 @@ const InfoButton = styled(Button)`
   opacity: 0.5;
   svg {
     fill: ${(props) =>
-      props.invert === 'true'
-        ? props.theme.themeColors.white
-        : props.theme.themeColors.black};
+      props.invert === 'true' ? props.theme.themeColors.white : props.theme.themeColors.black};
   }
 
   &:hover {
@@ -36,6 +45,7 @@ const PopoverTip = (props: PopoverTipProps) => {
 
   return (
     <>
+      <GlobalStyles />
       <InfoButton id={id} color="link" invert={invert.toString()}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -55,6 +65,7 @@ const PopoverTip = (props: PopoverTipProps) => {
         isOpen={tooltipOpen}
         autohide={false}
         toggle={toggle}
+        className="tooltip-container"
       >
         {content}
       </Tooltip>

--- a/src/components/general/OutcomeCard.tsx
+++ b/src/components/general/OutcomeCard.tsx
@@ -6,6 +6,8 @@ import { beautifyValue, getMetricChange, getMetricValue } from 'common/preproces
 import type { OutcomeNodeFieldsFragment } from 'common/__generated__/graphql';
 import Loader from 'components/common/Loader';
 import { useFeatures } from '@/common/instance';
+import { getHelpText } from './progress-tracking/utils';
+import PopoverTip from '../common/PopoverTip';
 
 const StyledTab = styled.div`
   flex: 0 0 175px;
@@ -20,7 +22,6 @@ const StyledTab = styled.div`
 const Header = styled.div`
   display: flex;
   justify-content: space-between;
-
   &.root h2 {
     font-size: 1.5rem;
   }
@@ -172,9 +173,11 @@ const OutcomeCard = (props: OutcomeCardProps) => {
   const lastMeasuredYear =
     node?.metric.historicalValues[node.metric.historicalValues.length - 1]?.year;
   const isForecast = !lastMeasuredYear || endYear > lastMeasuredYear;
-  const { maximumFractionDigits } = useFeatures();
+  const { maximumFractionDigits, showRefreshPrompt } = useFeatures();
 
-  // const unit = `kt CO<sub>2</sub>e${t('abbr-per-annum')}`;
+  // TODO: Remove the showRefreshPrompt check once help text is moved to node descriptions on the backend
+  const helpText = showRefreshPrompt ? getHelpText(node.id) : undefined;
+
   const unit = node.metric?.unit?.htmlShort;
 
   const handleClickTab = () => handleClick(node.id);
@@ -211,6 +214,7 @@ const OutcomeCard = (props: OutcomeCardProps) => {
           <Title color={color}>
             <Name>{node.shortName || node.name}</Name>
           </Title>
+          {helpText && <PopoverTip identifier={`${node.id}-help-text`} content={helpText} />}
         </Header>
 
         <Body>

--- a/src/components/general/OutcomeNodeContent.tsx
+++ b/src/components/general/OutcomeNodeContent.tsx
@@ -13,11 +13,13 @@ import DataTable from './DataTable';
 import OutcomeNodeDetails from './OutcomeNodeDetails';
 import type { OutcomeNodeFieldsFragment } from 'common/__generated__/graphql';
 import ScenarioBadge from 'components/common/ScenarioBadge';
-import { useInstance } from 'common/instance';
+import { useFeatures, useInstance } from 'common/instance';
 import DimensionalNodePlot from './DimensionalNodePlot';
 import { ProgressIndicator } from './progress-tracking/ProgressIndicator';
 import { getLatestProgressYear, hasProgressTracking } from '@/utils/progress-tracking';
 import { useSite } from '@/context/site';
+import PopoverTip from '../common/PopoverTip';
+import { getHelpText } from './progress-tracking/utils';
 
 const DisplayTab = styled(NavItem)`
   font-size: 0.9rem;
@@ -142,6 +144,7 @@ const OutcomeNodeContent = ({
   const showProgressTrackingStatus =
     node.metricDim && hasProgressTracking(node.metricDim, site.scenarios, site.minYear);
 
+  const { showRefreshPrompt } = useFeatures();
   const [activeTabId, setActiveTabId] = useState('graph');
   const showDistribution = instance.id === 'zuerich' && subNodes.length > 1;
   const nodesTotal = getMetricValue(node, endYear);
@@ -155,7 +158,8 @@ const OutcomeNodeContent = ({
   const nodeName = node.shortName || node.name;
   const showNodeLinks = !instance.features?.hideNodeDetails;
   const maximumFractionDigits = instance.features?.maximumFractionDigits ?? undefined;
-
+  // TODO: Remove showRefreshPrompt check when node help text is moved to the backend
+  const helpText = showRefreshPrompt ? getHelpText(node.id) : undefined;
   function onClickMeasuredEmissions(year: number) {
     setSelectedProgressYear(year);
     setProgressModalOpen(true);
@@ -205,6 +209,9 @@ const OutcomeNodeContent = ({
                 </NodeLink>
               ) : (
                 nodeName
+              )}
+              {helpText && (
+                <PopoverTip identifier={`${node.id}-card-help-text`} content={helpText} />
               )}
             </h4>
             <CardSetDescriptionDetails>

--- a/src/components/general/progress-tracking/utils.ts
+++ b/src/components/general/progress-tracking/utils.ts
@@ -58,3 +58,22 @@ export function getStatus(deltaPercentage: number, t: TFunction, theme: Theme): 
     subLabel: t('higher-than-expected', { percentage: deltaPercentage }),
   };
 }
+
+// TODO: Move to node descriptions on the backend
+// This is a temporary solution with non-translated text for NZC specific plans (only supported in English).
+const HELP_TEXT_BY_NODE_ID = new Map([
+  [
+    'waste_emissions',
+    'Waste emissions have a very small effect on overall city GHG and are assumed to be on plan in the Observed Emissions drill down.',
+  ],
+  [
+    'emissions_from_other_sectors',
+    'The "Other" sector includes all emissions not covered by the main categories: ' +
+      'Transport, Buildings & Heating, Electricity, Waste, and Freight. ' +
+      'It includes emissions from industrial processes and product use (IPPU) and agriculture.',
+  ],
+]);
+
+export function getHelpText(nodeId: string) {
+  return HELP_TEXT_BY_NODE_ID.get(nodeId);
+}


### PR DESCRIPTION
This contains a few quick n dirty solutions to enable tooltips for NetZeroPlanner plans. This logic should be moved to the backend ([Asana ticket](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1210701644230238?focus=true) 🎟️):
1. Text is hard coded rather than internationalised — fixed when node help text is available on the backend
2. We rely on a feature boolean (`showRefreshPrompt`) used only for NZP plans, implicitly stealing it for our purposes — fixed when node help text is available on the backend