### PR TITLE
Style MUI switches

### DIFF
--- a/src/common/mui-theme/components.ts
+++ b/src/common/mui-theme/components.ts
@@ -222,13 +222,13 @@ export function getComponents(theme: Theme): ThemeOptions['components'] {
     MuiSwitch: {
       styleOverrides: {
         root: {
-          width: 42,
-          height: 26,
+          width: 36,
+          height: 20,
           padding: 0,
           marginRight: 6,
           '&.MuiSwitch-sizeSmall': {
-            width: 34,
-            height: 18,
+            width: 32,
+            height: 16,
             padding: 0,
             marginRight: 6,
 
@@ -237,11 +237,11 @@ export function getComponents(theme: Theme): ThemeOptions['components'] {
               margin: 2,
             },
             '& .MuiSwitch-thumb': {
-              width: 14,
-              height: 14,
+              width: 12,
+              height: 12,
             },
             '& .MuiSwitch-track': {
-              borderRadius: 18 / 2,
+              borderRadius: 16 / 2,
             },
           },
           '& .MuiSwitch-switchBase': {
@@ -273,11 +273,11 @@ export function getComponents(theme: Theme): ThemeOptions['components'] {
           },
           '& .MuiSwitch-thumb': {
             boxSizing: 'border-box',
-            width: 22,
-            height: 22,
+            width: 16,
+            height: 16,
           },
           '& .MuiSwitch-track': {
-            borderRadius: 26 / 2,
+            borderRadius: 20 / 2,
             backgroundColor: theme.graphColors.grey030,
             opacity: 1,
           },

--- a/src/common/mui-theme/components.ts
+++ b/src/common/mui-theme/components.ts
@@ -222,24 +222,64 @@ export function getComponents(theme: Theme): ThemeOptions['components'] {
     MuiSwitch: {
       styleOverrides: {
         root: {
-          padding: 8,
+          width: 42,
+          height: 26,
+          padding: 0,
+          marginRight: 6,
+          '&.MuiSwitch-sizeSmall': {
+            width: 34,
+            height: 18,
+            padding: 0,
+            marginRight: 6,
+
+            '& .MuiSwitch-switchBase': {
+              padding: 0,
+              margin: 2,
+            },
+            '& .MuiSwitch-thumb': {
+              width: 14,
+              height: 14,
+            },
+            '& .MuiSwitch-track': {
+              borderRadius: 18 / 2,
+            },
+          },
           '& .MuiSwitch-switchBase': {
+            padding: 0,
+            margin: 2,
+            transitionDuration: '300ms',
             '&.Mui-checked': {
+              transform: 'translateX(16px)',
               color: theme.themeColors.white,
               '& + .MuiSwitch-track': {
                 backgroundColor: theme.brandDark,
+                opacity: 1,
+                border: 0,
               },
+              '&.Mui-disabled + .MuiSwitch-track': {
+                opacity: 0.5,
+              },
+            },
+            '&.Mui-focusVisible .MuiSwitch-thumb': {
+              color: theme.brandDark,
+              border: `6px solid ${theme.themeColors.white}`,
+            },
+            '&.Mui-disabled .MuiSwitch-thumb': {
+              color: theme.graphColors.grey010,
+            },
+            '&.Mui-disabled + .MuiSwitch-track': {
+              opacity: 0.7,
             },
           },
           '& .MuiSwitch-thumb': {
-            boxShadow: 'none',
-            width: 16,
-            height: 16,
-            margin: 2,
+            boxSizing: 'border-box',
+            width: 22,
+            height: 22,
           },
           '& .MuiSwitch-track': {
-            borderRadius: 16,
+            borderRadius: 26 / 2,
             backgroundColor: theme.graphColors.grey030,
+            opacity: 1,
           },
         },
       },

--- a/src/components/common/MuiThemeExample.tsx
+++ b/src/components/common/MuiThemeExample.tsx
@@ -8,10 +8,12 @@ import {
   CardContent,
   Chip,
   FormControl,
+  FormControlLabel,
   InputLabel,
   MenuItem,
   Select,
   Stack,
+  Switch,
   TextField,
   Typography,
 } from '@mui/material';
@@ -83,7 +85,7 @@ export function MuiThemeExample() {
           <Typography variant="h3" gutterBottom>
             Form Elements
           </Typography>
-          <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap>
+          <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap mb={2}>
             <TextField label="Text Field" placeholder="Enter some text..." variant="outlined" />
             <FormControl sx={{ minWidth: 200 }}>
               <InputLabel>Select Option</InputLabel>
@@ -97,6 +99,52 @@ export function MuiThemeExample() {
                 <MenuItem value="option3">Option 3</MenuItem>
               </Select>
             </FormControl>
+          </Stack>
+          <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap mb={2}>
+            <FormControlLabel
+              control={<Switch disabled={false} checked={true} />}
+              label="This is base switch on"
+              sx={{
+                m: 0,
+                p: 0,
+              }}
+            />
+            <FormControlLabel
+              control={<Switch disabled={false} checked={false} />}
+              label="This is base switch off"
+              sx={{
+                m: 0,
+                p: 0,
+              }}
+            />
+          </Stack>
+          <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap mb={2}>
+            <FormControlLabel
+              control={<Switch disabled={false} checked={true} size="small" />}
+              label="This is small switch on"
+              sx={{
+                m: 0,
+                p: 0,
+              }}
+              slotProps={{
+                typography: {
+                  variant: 'caption',
+                },
+              }}
+            />
+            <FormControlLabel
+              control={<Switch disabled={false} checked={false} size="small" />}
+              label="This is small switch off"
+              sx={{
+                m: 0,
+                p: 0,
+              }}
+              slotProps={{
+                typography: {
+                  variant: 'caption',
+                },
+              }}
+            />
           </Stack>
         </Box>
 


### PR DESCRIPTION
Only realised after completing the test page that the restyling was only needed for the small variant but here goes...

**Before**
<img width="495" height="229" alt="Screenshot 2025-08-06 at 15 59 55" src="https://github.com/user-attachments/assets/dadaeb2a-7bd4-4844-acec-945d9abcfbdc" />

**After**
<img width="478" height="218" alt="Screenshot 2025-08-06 at 16 05 11" src="https://github.com/user-attachments/assets/882d2d2d-628d-4323-8f1c-59b2cd75a515" />
