### PR TITLE
Make ActionCount display only visible actions number

### DIFF
--- a/src/components/pages/ActionListPage.tsx
+++ b/src/components/pages/ActionListPage.tsx
@@ -295,6 +295,11 @@ function ActionListPage({ page }: ActionListPageProps) {
     [data, actionGroup, activeEfficiency, yearRange, filteredActions, t]
   );
 
+  const displayedActionsCount = useMemo(() => {
+    const hasAnyGroup = usableActions.some((a) => a.group);
+    return hasAnyGroup ? usableActions.filter((a) => a.group).length : usableActions.length;
+  }, [usableActions]);
+
   const actionGroups = filteredActions.reduce(
     (groups: NonNullable<ActionWithEfficiency['group']>[], action) =>
       !action.group || groups.find((group) => group.id === action.group?.id)
@@ -424,7 +429,7 @@ function ActionListPage({ page }: ActionListPageProps) {
           </Row>
         </SettingsForm>
         <ActionCount>
-          <div>{t('actions-count', { count: usableActions.length })}</div>
+          <div>{t('actions-count', { count: displayedActionsCount })}</div>
         </ActionCount>
       </PageHero>
       <ActionsViewTabs>


### PR DESCRIPTION
Make ActionCount header show the number of only displayed actions (exclude ungrouped actions which we hide from the list).
Asana - https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1211079810379844?focus=true

<img width="1342" height="364" alt="Screenshot 2025-08-19 at 14 30 11" src="https://github.com/user-attachments/assets/ca727515-ab59-4321-97ca-0cdc3b98b110" />


