### PR TITLE
 Fix grey hell when action groups have no colours assigned

### DIFF
--- a/tsc-baseline.json
+++ b/tsc-baseline.json
@@ -4,18 +4,6 @@
     "ignoreMessages": false
   },
   "errors": {
-    "d4beb7ee9d5ec7d6b52969731db846db52c32059": {
-      "file": "src/common/colors.ts",
-      "code": "TS2345",
-      "count": 2,
-      "message": "Argument of type 'string[] | Color[] | { (t: number): Color; scale(): Scale<Color>; }' is not assignable to parameter of type 'BrewerPaletteName | ChromaInput[] | undefined'."
-    },
-    "99fb8de21497fb01cac474a5ca5c16e381ca9669": {
-      "file": "src/common/colors.ts",
-      "code": "TS2345",
-      "count": 2,
-      "message": "Argument of type 'string[] | Color[]' is not assignable to parameter of type 'string[]'."
-    },
     "d7b48510ef99dd1b8cbe48783e60f9131839eb0d": {
       "file": "src/common/preprocess.ts",
       "code": "TS2339",
@@ -100,11 +88,11 @@
       "count": 1,
       "message": "Argument of type 'null' is not assignable to parameter of type 'ElementRef | undefined'."
     },
-    "05ab1e02e83c59376151d802d7289c3a6c7a395c": {
+    "ee795aa0e8ff9ef0de663341e9c2d8f40c88d1f6": {
       "file": "src/components/common/GraphQLError.tsx",
       "code": "TS2345",
       "count": 1,
-      "message": "Argument of type '[\"errors:network-error\"]' is not assignable to parameter of type '[key: string | string[], options: TOptionsBase & $Dictionary & { defaultValue: never; }] | [key: string | string[], defaultValue: never, options?: (TOptionsBase & $Dictionary) | undefined] | [key: ...]'."
+      "message": "Argument of type '[\"errors:network-error\"]' is not assignable to parameter of type '[key: TemplateStringsArray | \"details\" | \"table\" | \"loading\" | \"pred\" | \"impact\" | \"reduction\" | \"abbr-per-annum\" | \"action-impact\" | \"action\" | \"action-name\" | ... 137 more ... | (TemplateStringsArray | ... 146 more ... | \"impact-compared-to-baseline\")[], options?: (TOptionsBase & $Dictionary) | undefined] | [key: ...'."
     },
     "1484f806f69e92e870e04470aab2e62401c4c6bf": {
       "file": "src/components/common/GraphQLError.tsx",
@@ -274,11 +262,11 @@
       "count": 3,
       "message": "Object is possibly 'null'."
     },
-    "aab0774a5531662965a7ab6b1f16a6372a1c7c47": {
+    "2168a3932184c85f5e03e92ff2f149f23fd5c048": {
       "file": "src/components/general/ActionsComparison.tsx",
       "code": "TS2345",
       "count": 1,
-      "message": "Argument of type '[string | null]' is not assignable to parameter of type '[key: string | string[], options: TOptionsBase & $Dictionary & { defaultValue: never; }] | [key: string | string[], defaultValue: never, options?: (TOptionsBase & $Dictionary) | undefined] | [key: ...]'."
+      "message": "Argument of type '[string | null]' is not assignable to parameter of type '[key: TemplateStringsArray | \"details\" | \"table\" | \"loading\" | \"pred\" | \"impact\" | \"reduction\" | \"abbr-per-annum\" | \"action-impact\" | \"action\" | \"action-name\" | ... 137 more ... | (TemplateStringsArray | ... 146 more ... | \"impact-compared-to-baseline\")[], options?: (TOptionsBase & $Dictionary) | undefined] | [key: ...'."
     },
     "ea89aeadcf94e9ffda4f621429a6f6ee1a5697fb": {
       "file": "src/components/general/BarGraph.tsx",
@@ -364,11 +352,11 @@
       "count": 2,
       "message": "Property 'data' is private and only accessible within class 'DimensionalMetric'."
     },
-    "f09f8c4d045c9ee4f3dd91121e56c2987bf88464": {
+    "aae4e22e4c4a846e66ecab956a60b66fdabd06ae": {
       "file": "src/components/general/CostBenefitAnalysis.tsx",
       "code": "TS2345",
       "count": 1,
-      "message": "Argument of type '[string]' is not assignable to parameter of type '[key: string | string[], options: TOptionsBase & $Dictionary & { defaultValue: never; }] | [key: string | string[], defaultValue: never, options?: (TOptionsBase & $Dictionary) | undefined] | [key: ...]'."
+      "message": "Argument of type '[string]' is not assignable to parameter of type '[key: TemplateStringsArray | \"details\" | \"table\" | \"loading\" | \"pred\" | \"impact\" | \"reduction\" | \"abbr-per-annum\" | \"action-impact\" | \"action\" | \"action-name\" | ... 137 more ... | (TemplateStringsArray | ... 146 more ... | \"impact-compared-to-baseline\")[], options?: (TOptionsBase & $Dictionary) | undefined] | [key: ...'."
     },
     "3186d64cd5707a556087f33ee127a5a37c67d25b": {
       "file": "src/components/general/CostBenefitAnalysis.tsx",
@@ -490,66 +478,6 @@
       "count": 1,
       "message": "Type '{ compact: true; }' is not assignable to type 'IntrinsicAttributes'."
     },
-    "a17350401a1fa6c362259ade8dfb144356a6437d": {
-      "file": "src/components/general/OutcomeCard.tsx",
-      "code": "TS2345",
-      "count": 2,
-      "message": "Argument of type 'OutcomeNodeFieldsFragment' is not assignable to parameter of type '{ metric: NodeMetric; }'."
-    },
-    "3691bb7a9cbe2b72cd128a0be250569bb318d9dc": {
-      "file": "src/components/general/OutcomeCard.tsx",
-      "code": "TS2345",
-      "count": 1,
-      "message": "Argument of type 'number | undefined' is not assignable to parameter of type 'number'."
-    },
-    "cd3538339bb6517ec6bb2d3dec8052e51928bba5": {
-      "file": "src/components/general/OutcomeCard.tsx",
-      "code": "TS18047",
-      "count": 2,
-      "message": "'node.metric' is possibly 'null'."
-    },
-    "bca86c5d604dbc51572c876845dba6e326b62111": {
-      "file": "src/components/general/OutcomeCard.tsx",
-      "code": "TS18048",
-      "count": 1,
-      "message": "'goalOutcomeValue' is possibly 'undefined'."
-    },
-    "f0dbdb3907f529c6f36e9579a467d108e6472832": {
-      "file": "src/components/general/OutcomeCardSet.tsx",
-      "code": "TS2345",
-      "count": 1,
-      "message": "Argument of type 'OutcomeNodeFieldsFragment[]' is not assignable to parameter of type '{ metric: NodeMetric; }[]'."
-    },
-    "fe787eb73ce93a00516de4e58681b052a0489d16": {
-      "file": "src/components/general/OutcomeCardSet.tsx",
-      "code": "TS2532",
-      "count": 6,
-      "message": "Object is possibly 'undefined'."
-    },
-    "5a6aa5a375e6eee22cf617a1effc6c0cae88edf2": {
-      "file": "src/components/general/OutcomeCardSet.tsx",
-      "code": "TS2345",
-      "count": 6,
-      "message": "Argument of type 'OutcomeNodeFieldsFragment' is not assignable to parameter of type '{ metric: NodeMetric; }'."
-    },
-    "98094abccc147db449bc28e76a5131228ac839e6": {
-      "file": "src/components/general/OutcomeCardSet.tsx",
-      "code": "TS2345",
-      "count": 1,
-      "message": "Argument of type '[string | null]' is not assignable to parameter of type '[key: string | string[], options: TOptionsBase & $Dictionary & { defaultValue: never; }] | [key: string | string[], defaultValue: never, options?: (TOptionsBase & $Dictionary) | undefined] | [key: ...]'."
-    },
-    "1344e7affcf6ca4a1ab90dd81bb334ff0a1ef45b": {
-      "file": "src/components/general/OutcomeCardSet.tsx",
-      "code": "TS2345",
-      "count": 2,
-      "message": "Argument of type '{ id: string; name: string; color: string | null; order: number | null; shortName: string | null; shortDescription: string | null; targetYearGoal: number | null; quantity: string | null; ... 7 more ...; __typename: \"Node\"; }[]' is not assignable to parameter of type '{ metric: NodeMetric; }[]'."
-    },
-    "cc5872d2a8948be1f84cbf8b08db50f0e6ce26ff": {
-      "file": "src/components/general/OutcomeCardSet.tsx",
-      "code": "TS2345",
-      "count": 2,
-      "message": "Argument of type '{ id: string; name: string; color: string | null; order: number | null; shortName: string | null; shortDescription: string | null; targetYearGoal: number | null; quantity: string | null; ... 7 more ...; __typename: \"Node\"; }' is not assignable to parameter of type '{ metric: NodeMetric; }'."
-    },
     "e3a2d64a5d7cc9e6007790f7e6a33440c1a2b341": {
       "file": "src/components/general/OutcomeGraph.tsx",
       "code": "TS18047",
@@ -585,30 +513,6 @@
       "code": "TS18047",
       "count": 2,
       "message": "'parentNode.metric' is possibly 'null'."
-    },
-    "67f7823cabf89d8a4e76f05b68646286abcafa22": {
-      "file": "src/components/general/OutcomeNodeContent.tsx",
-      "code": "TS2345",
-      "count": 2,
-      "message": "Argument of type 'OutcomeNodeFieldsFragment' is not assignable to parameter of type '{ metric: NodeMetric; }'."
-    },
-    "e143b5ce25276976fc028c45155665d95a5a0286": {
-      "file": "src/components/general/OutcomeNodeContent.tsx",
-      "code": "TS18048",
-      "count": 2,
-      "message": "'lastMeasuredYear' is possibly 'undefined'."
-    },
-    "57d9cce8605f12a7013b094147e52142a07de8f2": {
-      "file": "src/components/general/OutcomeNodeContent.tsx",
-      "code": "TS2345",
-      "count": 1,
-      "message": "Argument of type 'number | undefined' is not assignable to parameter of type 'number'."
-    },
-    "c5084a2849b943df6d2656bc62a01aa4e415593c": {
-      "file": "src/components/general/OutcomeNodeContent.tsx",
-      "code": "TS2322",
-      "count": 1,
-      "message": "Type '{ node: OutcomeNodeFieldsFragment; metric: { id: string; name: string; stackable: boolean; forecastFrom: number | null; years: number[]; values: number[]; dimensions: ({ ...; } & { ...; })[]; goals: ({ ...; } & { ...; })[]; unit: { ...; } & { ...; }; normalizedBy: ({ ...; } & { ...; }) | null; } & { ...; }; ... 5 mo...' is not assignable to type 'IntrinsicAttributes & DimensionalNodeVisualisationProps'."
     },
     "791fd92d417103c3a38194c36470dcbc3acb2724": {
       "file": "src/components/general/OutcomeNodeDetails.tsx",
@@ -687,24 +591,6 @@
       "code": "TS2339",
       "count": 1,
       "message": "Property 'invertImpact' does not exist on type '{ id: string; label: string; plotLimitForIndicator: number | null; indicatorUnit: { htmlShort: string; } & { __typename: \"UnitType\"; }; costUnit: ({ htmlShort: string; } & { __typename: \"UnitType\"; }) | null; effectUnit: ({ ...; } & { ...; }) | null; costNode: ({ ...; } & { ...; }) | null; effectNode: { ...; } & { ....'."
-    },
-    "1513ea577f1e140519298dffbc080c8bfb87a7b0": {
-      "file": "src/components/pages/OutcomePage.tsx",
-      "code": "TS2339",
-      "count": 1,
-      "message": "Property 'id' does not exist on type '{ __typename: \"ActionNode\"; } | ({ id: string; name: string; color: string | null; order: number | null; shortName: string | null; shortDescription: string | null; targetYearGoal: number | null; ... 7 more ...; metricDim: ({ ...; } & { ...; }) | null; } & { ...; })'."
-    },
-    "d68ac9a552f736d1abac2005ec53adb3edbc642e": {
-      "file": "src/components/pages/OutcomePage.tsx",
-      "code": "TS2345",
-      "count": 1,
-      "message": "Argument of type 'Map<any, { __typename: \"ActionNode\"; } | ({ id: string; name: string; color: string | null; order: number | null; shortName: string | null; shortDescription: string | null; targetYearGoal: number | null; ... 7 more ...; metricDim: ({ ...; } & { ...; }) | null; } & { ...; })>' is not assignable to parameter of type 'Map<string, OutcomeNodeFieldsFragment>'."
-    },
-    "63dc38231528da4a10c5573510c49a1dab0d4170": {
-      "file": "src/components/pages/OutcomePage.tsx",
-      "code": "TS2322",
-      "count": 1,
-      "message": "Type 'Map<any, { __typename: \"ActionNode\"; } | ({ id: string; name: string; color: string | null; order: number | null; shortName: string | null; shortDescription: string | null; targetYearGoal: number | null; ... 7 more ...; metricDim: ({ ...; } & { ...; }) | null; } & { ...; })>' is not assignable to type 'Map<string, OutcomeNodeFieldsFragment>'."
     },
     "0ffca2d6c30523720b83a07e15a250dc85c225df": {
       "file": "src/middleware/lru-cache.ts",


### PR DESCRIPTION
Action groups can have no colour assigned, this caused our action chart to look very grey and the legend to break. 

### Example with no colours set on the backend
| Before | After |
|-|-|
| <img width="1109" height="690" alt="image" src="https://github.com/user-attachments/assets/57826864-db8d-4564-91e2-ed3222f7646d" /> | <img width="1113" height="695" alt="image" src="https://github.com/user-attachments/assets/1366f844-beaf-42c8-8d9e-19712cb94682" /> |

### Example with colour set on the backend 
| Before | After |
|-|-|
| <img width="1113" height="730" alt="image" src="https://github.com/user-attachments/assets/c557d507-ffe5-4787-8337-a06d382f0724" /> |  <img width="1110" height="736" alt="image" src="https://github.com/user-attachments/assets/8b0e65c2-6abe-4ed5-ae95-b51ab41ea006" /> |