### PR TITLE
Update action impact legend styles

### DIFF
--- a/src/components/general/resident-dashboard/DashboardVisualizationActionImpact.tsx
+++ b/src/components/general/resident-dashboard/DashboardVisualizationActionImpact.tsx
@@ -1,16 +1,7 @@
 import React from 'react';
 
 import { useTheme } from '@emotion/react';
-import {
-  Box,
-  Card,
-  CardContent,
-  Divider,
-  Grid,
-  Stack,
-  type Theme,
-  Typography,
-} from '@mui/material';
+import { Box, Card, CardContent, Divider, Stack, type Theme, Typography } from '@mui/material';
 import type { EChartsCoreOption } from 'echarts/core';
 import type { CallbackDataParams } from 'echarts/types/dist/shared';
 
@@ -45,28 +36,37 @@ const Legend = ({ groups }: { groups: ActionGroup[] }) => {
   const theme = useTheme();
 
   return (
-    <Grid container sx={{ mt: 2, mb: 1, alignItems: 'center' }} rowSpacing={0.5} columnSpacing={1}>
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+        my: 2,
+        gap: 1,
+      }}
+    >
       {groups
         .filter((group) => !!group.color)
         .map((group) => (
-          <Grid key={group.id} size={{ xs: 12, sm: 6, md: 4, lg: 3, xl: 2 }}>
-            <Stack direction="row" spacing={0.5} alignItems="center">
-              <Box
-                sx={{
-                  flexShrink: 0,
-                  backgroundColor: group.color,
-                  width: 16,
-                  height: 16,
-                  borderRadius: theme.badgeBorderRadius,
-                }}
-              />
-              <Typography variant="body2" color="text.secondary">
-                {group.name}
-              </Typography>
-            </Stack>
-          </Grid>
+          <Stack key={group.id} direction="row" spacing={0.5} alignItems="center">
+            <Box
+              sx={{
+                flexShrink: 0,
+                backgroundColor: group.color,
+                width: 16,
+                height: 16,
+                borderRadius: theme.badgeBorderRadius,
+              }}
+            />
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ lineHeight: (theme) => theme.lineHeightSm }}
+            >
+              {group.name}
+            </Typography>
+          </Stack>
         ))}
-    </Grid>
+    </Box>
   );
 };
 


### PR DESCRIPTION
- Reduce the lineheight
- Switch MUI grid out for a basic CSS grid so that we fit as many items as possible in a row, no need for predefined column widths

<img width="1085" height="592" alt="sunnydale localhost_3000_overview (1)" src="https://github.com/user-attachments/assets/29c41558-c21f-4602-b60e-85f630ad2b13" />
<img width="817" height="592" alt="sunnydale localhost_3000_overview" src="https://github.com/user-attachments/assets/fd578090-1d1f-4b42-864c-72c0bf1ae9a7" />
<img width="700" height="592" alt="potsdam-gpc localhost_3000_example-dashboard (4)" src="https://github.com/user-attachments/assets/dfce2ff6-ec6b-42ba-a59e-4c5a0d4fba22" />
<img width="1021" height="592" alt="potsdam-gpc localhost_3000_example-dashboard (3)" src="https://github.com/user-attachments/assets/c9c3b5bc-a52c-473b-906b-4f60cc49ece9" />
<img width="1264" height="592" alt="potsdam-gpc localhost_3000_example-dashboard (2)" src="https://github.com/user-attachments/assets/2a98c04d-b6a2-49ba-a11c-69a0e6477696" />
