### PR TITLE
Disable animation on baseline and goal values

### DIFF
--- a/src/components/general/NodeGraph.tsx
+++ b/src/components/general/NodeGraph.tsx
@@ -485,6 +485,7 @@ function createGoalSeries(theme: Theme, datasetIndex: number, name: string) {
     lineStyle: {
       color: 'rgba(0, 0, 0, 0)',
     },
+    animation: false,
   };
 }
 
@@ -501,6 +502,7 @@ function createBaselineSeries(theme: Theme, datasetIndex: number, name: string) 
       type: 'dashed',
     },
     color: theme.graphColors.grey060,
+    animation: false,
   };
 }
 


### PR DESCRIPTION
Fixes an issue where the baseline and goal would animate in when changing subsector tabs

🎟️ [Asana Task](https://app.asana.com/1/1201243246741462/project/1209894780050709/task/1211077991997915)

https://github.com/user-attachments/assets/4d26194f-d3b1-4970-98a9-dfecea4769fb

