### PR TITLE
Use scrollable pie legend for many categories

### DIFF
--- a/src/components/general/resident-dashboard/DashboardVisualizationDimension.tsx
+++ b/src/components/general/resident-dashboard/DashboardVisualizationDimension.tsx
@@ -46,6 +46,7 @@ const DashboardVisualizationDimension = ({ data, chartLabel, unit }: Props) => {
       orient: 'vertical',
       left: 'right',
       top: 'center',
+      type: 'scroll',
       textStyle: {
         width: 200,
         overflow: 'break',


### PR DESCRIPTION
Small one, in cases where there are many pie legend items, scroll the legend rather than breaking the layout. In reality I expect/ hope users won't use the pie chart to visualise so many categories, a bar chart would be better for suited for this.

[🎟️  Asana Task](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1211125688251879?focus=true)

| Before | After |
|-|-|
| <img width="744" height="362" alt="image" src="https://github.com/user-attachments/assets/f94c3422-10f5-4c86-b489-49045afd342f" /> | <img width="745" height="360" alt="image" src="https://github.com/user-attachments/assets/48c68e38-83ef-44ad-a633-9164f9718585" /> |