### PR TITLE
Show year against progress visualisation charts

### DIFF
--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -1695,6 +1695,14 @@ export type MetricDimensionCategoryValueFieldsFragment = (
   & { __typename: 'MetricDimensionCategoryValue' }
 );
 
+export type ScenarioValueFieldsFragment = (
+  { value: number | null, year: number, scenario: (
+    { id: string, name: string }
+    & { __typename: 'ScenarioType' }
+  ) }
+  & { __typename: 'ScenarioValue' }
+);
+
 export type DashboardPageFieldsFragment = (
   { backgroundColor: string | null, dashboardCards: Array<{ __typename: 'ActionImpactBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CallToActionBlock' | 'CardListBlock' | 'CategoryBreakdownBlock' | 'CharBlock' | 'ChoiceBlock' | 'CurrentProgressBarBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'FloatBlock' | 'GoalProgressBarBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'IntegerBlock' } | { __typename: 'ListBlock' | 'PageChooserBlock' | 'RawHTMLBlock' | 'ReferenceProgressBarBlock' | 'RegexBlock' | 'RichTextBlock' | 'ScenarioProgressBarBlock' | 'SnippetChooserBlock' | 'StaticBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | (
     { title: string, description: string, goalValue: number | null, referenceYearValue: number | null, lastHistoricalYearValue: number | null, image: (

--- a/src/queries/getPage.js
+++ b/src/queries/getPage.js
@@ -40,24 +40,28 @@ const DASHBOARD_PAGE_FRAGMENT = gql`
       __typename
       id
       ... on GoalProgressBarBlock {
+        __typename
         title
         description
         chartLabel
         color
       }
       ... on CurrentProgressBarBlock {
+        __typename
         title
         description
         chartLabel
         color
       }
       ... on ReferenceProgressBarBlock {
+        __typename
         title
         description
         chartLabel
         color
       }
       ... on ScenarioProgressBarBlock {
+        __typename
         title
         description
         chartLabel
@@ -92,6 +96,15 @@ const DASHBOARD_PAGE_FRAGMENT = gql`
     year
   }
 
+  fragment ScenarioValueFields on ScenarioValue {
+    scenario {
+      id
+      name
+    }
+    value
+    year
+  }
+
   fragment DashboardPageFields on DashboardPage {
     backgroundColor
     dashboardCards {
@@ -112,12 +125,7 @@ const DASHBOARD_PAGE_FRAGMENT = gql`
         referenceYearValue
         lastHistoricalYearValue
         scenarioValues {
-          scenario {
-            id
-            name
-          }
-          value
-          year
+          ...ScenarioValueFields
         }
         metricDimensionCategoryValues {
           ...MetricDimensionCategoryValueFields


### PR DESCRIPTION
- Show the corresponding year of a progress bar visualisation next to the chart label. 
- Refactor `DashboardVisualizationProgress` slightly to move common props across progress bar `items` to top level component props

[🎟️  Asana Task](https://app.asana.com/1/1201243246741462/project/1205309956497857/task/1211098896249995?focus=true)

TODO: Add the year for goal progress bars when available on the backend.

<img width="773" height="825" alt="image" src="https://github.com/user-attachments/assets/58edbf4d-6511-4744-917c-6f371c856366" />
