### PR TITLE
Add target year for progress visualisation

### DIFF
--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -1705,7 +1705,7 @@ export type ScenarioValueFieldsFragment = (
 
 export type DashboardPageFieldsFragment = (
   { backgroundColor: string | null, dashboardCards: Array<{ __typename: 'ActionImpactBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CallToActionBlock' | 'CardListBlock' | 'CategoryBreakdownBlock' | 'CharBlock' | 'ChoiceBlock' | 'CurrentProgressBarBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'FloatBlock' | 'GoalProgressBarBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'IntegerBlock' } | { __typename: 'ListBlock' | 'PageChooserBlock' | 'RawHTMLBlock' | 'ReferenceProgressBarBlock' | 'RegexBlock' | 'RichTextBlock' | 'ScenarioProgressBarBlock' | 'SnippetChooserBlock' | 'StaticBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | (
-    { title: string, description: string, goalValue: number | null, referenceYearValue: number | null, lastHistoricalYearValue: number | null, image: (
+    { title: string, description: string, referenceYearValue: number | null, lastHistoricalYearValue: number | null, image: (
       { url: string }
       & { __typename: 'ImageObjectType' }
     ) | null, node: (
@@ -1714,7 +1714,10 @@ export type DashboardPageFieldsFragment = (
     ), unit: (
       { short: string, htmlShort: string, htmlLong: string }
       & { __typename: 'UnitType' }
-    ), scenarioValues: Array<(
+    ), goalValues: Array<(
+      { year: number, value: number }
+      & { __typename: 'MetricYearlyGoalType' }
+    ) | null> | null, scenarioValues: Array<(
       { value: number | null, year: number, scenario: (
         { id: string, name: string }
         & { __typename: 'ScenarioType' }
@@ -1861,7 +1864,7 @@ export type GetPageQuery = (
     & { __typename: 'ActionListPage' }
   ) | (
     { id: string | null, title: string, backgroundColor: string | null, dashboardCards: Array<{ __typename: 'ActionImpactBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CallToActionBlock' | 'CardListBlock' | 'CategoryBreakdownBlock' | 'CharBlock' | 'ChoiceBlock' | 'CurrentProgressBarBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'FloatBlock' | 'GoalProgressBarBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'IntegerBlock' } | { __typename: 'ListBlock' | 'PageChooserBlock' | 'RawHTMLBlock' | 'ReferenceProgressBarBlock' | 'RegexBlock' | 'RichTextBlock' | 'ScenarioProgressBarBlock' | 'SnippetChooserBlock' | 'StaticBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | (
-      { title: string, description: string, goalValue: number | null, referenceYearValue: number | null, lastHistoricalYearValue: number | null, image: (
+      { title: string, description: string, referenceYearValue: number | null, lastHistoricalYearValue: number | null, image: (
         { url: string }
         & { __typename: 'ImageObjectType' }
       ) | null, node: (
@@ -1870,7 +1873,10 @@ export type GetPageQuery = (
       ), unit: (
         { short: string, htmlShort: string, htmlLong: string }
         & { __typename: 'UnitType' }
-      ), scenarioValues: Array<(
+      ), goalValues: Array<(
+        { year: number, value: number }
+        & { __typename: 'MetricYearlyGoalType' }
+      ) | null> | null, scenarioValues: Array<(
         { value: number | null, year: number, scenario: (
           { id: string, name: string }
           & { __typename: 'ScenarioType' }

--- a/src/components/general/resident-dashboard/DashboardVisualizationProgress.tsx
+++ b/src/components/general/resident-dashboard/DashboardVisualizationProgress.tsx
@@ -50,6 +50,7 @@ type Props = {
   scenarioValues?: ScenarioValueFieldsFragment[];
   maxValue: number;
   unit?: Omit<UnitFieldsFragment, '__typename'>;
+  goalYear?: number;
 };
 
 function getBarColor(
@@ -194,7 +195,8 @@ function TargetVariation({ item }: { item: DashboardProgressItem }) {
 function getYear(
   item: DashboardProgressItem,
   instance: InstanceContextType,
-  scenarioValues: ScenarioValueFieldsFragment[]
+  scenarioValues: ScenarioValueFieldsFragment[],
+  goalYear?: number
 ) {
   if (item.type === ProgressType.SCENARIO) {
     return scenarioValues.find((scenario) => scenario.scenario.id === item.scenarioId)?.year;
@@ -204,9 +206,8 @@ function getYear(
     return instance.maximumHistoricalYear;
   }
 
-  // TODO: Pending backend implementation
   if (item.type === ProgressType.GOAL) {
-    return undefined;
+    return goalYear;
   }
 
   if (item.type === ProgressType.REFERENCE) {
@@ -214,7 +215,13 @@ function getYear(
   }
 }
 
-const DashboardVisualizationProgress = ({ items = [], scenarioValues, unit, maxValue }: Props) => {
+const DashboardVisualizationProgress = ({
+  items = [],
+  scenarioValues,
+  unit,
+  maxValue,
+  goalYear,
+}: Props) => {
   const [expanded, setExpanded] = useState<number[]>([]);
 
   const instance = useInstance();
@@ -263,7 +270,7 @@ const DashboardVisualizationProgress = ({ items = [], scenarioValues, unit, maxV
       <Stack>
         {items.map((item, idx) => {
           const isItemExpanded = expanded.includes(idx);
-          const year = getYear(item, instance, scenarioValues ?? []);
+          const year = getYear(item, instance, scenarioValues ?? [], goalYear);
 
           return (
             <Accordion

--- a/src/queries/getPage.js
+++ b/src/queries/getPage.js
@@ -121,7 +121,10 @@ const DASHBOARD_PAGE_FRAGMENT = gql`
         unit {
           ...UnitFields
         }
-        goalValue
+        goalValues {
+          year
+          value
+        }
         referenceYearValue
         lastHistoricalYearValue
         scenarioValues {


### PR DESCRIPTION
Show the corresponding year of target progress visualisations next to the chart label. 

An instance can have multiple goals and each goal can have multiple values for different years. The new `goalValues` field returns all values for the selected goal index. We display the last goal value in cases where there's more than one, if user's request it, we could consider allowing the user to select a specific goal value.

[🎟️  Asana Task](https://app.asana.com/1/1201243246741462/project/1205309956497857/task/1211098896249995?focus=true)
