### PR TITLE
Prevent bar value being clipped

### DIFF
--- a/src/components/general/resident-dashboard/DashboardVisualizationActionImpact.tsx
+++ b/src/components/general/resident-dashboard/DashboardVisualizationActionImpact.tsx
@@ -151,8 +151,8 @@ const DashboardVisualizationActionImpact = ({ actions, chartLabel, unit }: Props
       containLabel: true,
       top: 0,
       bottom: 0,
-      left: 0,
-      right: 0,
+      left: 40,
+      right: 40,
     },
     legend: {
       show: false,


### PR DESCRIPTION
Teeny tiny one. Fixes [The number on the top of the tallest bar does not show](https://app.asana.com/1/1201243246741462/project/1209894780050709/task/1211125688251886?focus=true).