### PR TITLE
Use the actual baseline scenario name in actions impact texts

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/public/locales/cs/common.json
+++ b/public/locales/cs/common.json
@@ -116,10 +116,10 @@
   "thumbSliderLabel": "Upravit",
   "reset-button": "Resetovat",
   "outcomes": "Výsledky",
-  "impact-compared-to-baseline": "<strong>Celkový dopad {{impact}} {{unit}}</strong> ve srovnání se scénářem běžného vývoje",
+  "impact-compared-to-baseline": "<strong>Celkový dopad {{impact}} {{unit}}</strong> ve srovnání se {{baseline}} scénářem",
   "above-target": "nad cílem",
   "below-target": "pod cílem",
-   "action-name": "Název",
+  "action-name": "Název",
   "annual-impact": "Roční dopad",
   "how-calculated": "Jak se to počítá",
   "included-in-scenario": "Zahrnuto ve scénáři"

--- a/public/locales/da/common.json
+++ b/public/locales/da/common.json
@@ -115,7 +115,7 @@
   "thumbSliderLabel": "Juster",
   "reset-button": "Nulstil",
   "outcomes": "Resultater",
-  "impact-compared-to-baseline": "<strong>Samlet påvirkning {{impact}} {{unit}}</strong> sammenlignet med business-as-usual scenarie",
+  "impact-compared-to-baseline": "<strong>Samlet påvirkning {{impact}} {{unit}}</strong> sammenlignet med {{baseline}} scenarie",
   "above-target": "over målet",
   "below-target": "under målet",
   "action-name": "Navn",

--- a/public/locales/de-CH/common.json
+++ b/public/locales/de-CH/common.json
@@ -20,7 +20,7 @@
   "ktco2-e": "kt CO<sub>2</sub>-Äquivalente/a",
   "net-cost": "Nettokosten",
   "outcomes": "Ergebnisse",
-  "impact-compared-to-baseline": "<strong>Gesamtauswirkung {{impact}} {{unit}}</strong> im Vergleich zum Referenzszenario",
+  "impact-compared-to-baseline": "<strong>Gesamtauswirkung {{impact}} {{unit}}</strong> im Vergleich zum {{baseline}} Szenario",
   "show": "Anzeigen:",
   "action-name": "Name",
   "annual-impact": "Jährliche Wirkung",

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -114,7 +114,7 @@
   "financial-impact": "Finanzielle Auswirkungen",
   "net-cost": "Nettokosten",
   "reduction": "Reduzierung",
-  "impact-compared-to-baseline": "<strong>Gesamtauswirkung {{impact}} {{unit}}</strong> im Vergleich zum Referenzszenario",
+  "impact-compared-to-baseline": "<strong>Gesamtauswirkung {{impact}} {{unit}}</strong> im Vergleich zum {{baseline}} Szenario",
   "above-target": "über dem Ziel",
   "below-target": "unter dem Ziel"
 }

--- a/public/locales/el/common.json
+++ b/public/locales/el/common.json
@@ -132,7 +132,7 @@
   "emission-drivers": "Οδηγοί εκπομπών",
   "emissions-by-sector": "Εκπομπές ανά τομέα ({{year}})",
   "outcomes": "Αποτελέσματα",
-  "impact-compared-to-baseline": "<strong>Συνολική επίπτωση {{impact}} {{unit}}</strong> σε σύγκριση με το σενάριο συνήθους πορείας",
+  "impact-compared-to-baseline": "<strong>Συνολική επίπτωση {{impact}} {{unit}}</strong> σε σύγκριση με το {{baseline}} σενάριο",
   "above-target": "πάνω από τον στόχο",
   "below-target": "κάτω από τον στόχο",
   "action-name": "Όνομα",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -146,5 +146,5 @@
   "values-per": "Values per {{normalization}}",
   "above-target": "above the target",
   "below-target": "below the target",
-  "impact-compared-to-baseline": "<strong>Total impact {{impact}} {{unit}}</strong> compared to business as usual scenario"
+  "impact-compared-to-baseline": "<strong>Total impact {{impact}} {{unit}}</strong> compared to {{baseline}} scenario"
 }

--- a/public/locales/es-US/common.json
+++ b/public/locales/es-US/common.json
@@ -120,7 +120,7 @@
   "close": "Cerrar",
   "coming-soon": "Próximamente",
   "outcomes": "Resultados",
-  "impact-compared-to-baseline": "<strong>Impacto total {{impact}} {{unit}}</strong> comparado con el escenario de continuidad",
+  "impact-compared-to-baseline": "<strong>Impacto total {{impact}} {{unit}}</strong> comparado con el {{baseline}} escenario",
   "above-target": "por encima del objetivo",
   "below-target": "por debajo del objetivo",
   "action-name": "Nombre",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -109,7 +109,7 @@
   "reset-button": "Nollaa",
   "plot-choose-dimension": "Valitse dimensio",
   "outcomes": "Lopputulemat",
-  "impact-compared-to-baseline": "<strong>Kokonaisvaikutus {{impact}} {{unit}}</strong> verrattuna jatkuvuusskenaarioon",
+  "impact-compared-to-baseline": "<strong>Kokonaisvaikutus {{impact}} {{unit}}</strong> verrattuna {{baseline}} skenaarioon",
   "above-target": "yli tavoitteen",
   "below-target": "alle tavoitteen",
   "action-name": "Nimi",

--- a/public/locales/lv/common.json
+++ b/public/locales/lv/common.json
@@ -105,7 +105,7 @@
   "tco2-e-inhabitant": "t CO<sub>2</sub>eq/iedzīvotājs/g",
   "ktco2-e": "kt CO<sub>2</sub>eq/g",
   "outcomes": "Rezultāti",
-  "impact-compared-to-baseline": "<strong>Kopējā ietekme {{impact}} {{unit}}</strong> salīdzinājumā ar ierasto attīstības scenāriju",
+  "impact-compared-to-baseline": "<strong>Kopējā ietekme {{impact}} {{unit}}</strong> salīdzinājumā ar {{baseline}} scenāriju",
   "above-target": "pārsniedz mērķi",
   "below-target": "nepārsniedz mērķi",
   "action-name": "Nosaukums",

--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -116,7 +116,7 @@
   "thumbSliderLabel": "Dostosuj",
   "reset-button": "Resetuj",
   "outcomes": "Wyniki",
-  "impact-compared-to-baseline": "<strong>Całkowity wpływ {{impact}} {{unit}}</strong> w porównaniu ze scenariuszem kontynuacji",
+  "impact-compared-to-baseline": "<strong>Całkowity wpływ {{impact}} {{unit}}</strong> w porównaniu ze {{baseline}} scenariuszem",
   "above-target": "powyżej celu",
   "below-target": "poniżej celu",
   "action-name": "Nazwa",

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -101,7 +101,7 @@
   "table-unit": "Enhet",
   "plot-choose-dimension": "Välj dimension",
   "outcomes": "Resultat",
-  "impact-compared-to-baseline": "<strong>Total påverkan {{impact}} {{unit}}</strong> jämfört med referensscenariot",
+  "impact-compared-to-baseline": "<strong>Total påverkan {{impact}} {{unit}}</strong> jämfört med {{baseline}} scenariot",
   "above-target": "över målet",
   "below-target": "under målet",
   "action-name": "Namn",

--- a/src/components/general/resident-dashboard/DashboardVisualizationActionImpact.tsx
+++ b/src/components/general/resident-dashboard/DashboardVisualizationActionImpact.tsx
@@ -4,10 +4,13 @@ import { useTheme } from '@emotion/react';
 import { Box, Card, CardContent, Divider, Stack, type Theme, Typography } from '@mui/material';
 import type { EChartsCoreOption } from 'echarts/core';
 import type { CallbackDataParams } from 'echarts/types/dist/shared';
+import { useTranslation } from 'react-i18next';
 
 import { Chart } from '@common/components/Chart';
 
-import { Trans, useTranslation } from '@/common/i18n';
+import { ScenarioKind } from '@/common/__generated__/graphql';
+import { Trans } from '@/common/i18n';
+import { useSiteWithSetter } from '@/context/site';
 
 type ActionGroup = {
   id: string;
@@ -102,7 +105,9 @@ function getGroupColor(group: ActionGroup, theme: Theme, index: number) {
 const DashboardVisualizationActionImpact = ({ actions, chartLabel, unit }: Props) => {
   const theme = useTheme();
   const { t } = useTranslation();
+  const [site] = useSiteWithSetter();
   const year = actions[0]?.year;
+  const baselineScenario = site.scenarios.find(({ kind }) => kind === ScenarioKind.Baseline);
 
   const filteredActions = actions
     .filter((action) => action.isEnabled)
@@ -247,6 +252,7 @@ const DashboardVisualizationActionImpact = ({ actions, chartLabel, unit }: Props
                     ? `+${totalImpact.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
                     : totalImpact.toLocaleString(undefined, { maximumFractionDigits: 0 }),
                 unit: unit || '',
+                baseline: baselineScenario?.name || t('plot-baseline'),
               }}
             />
           </Typography>


### PR DESCRIPTION
Fixes [🎟️  "Jatkuvuusskenaario" is a strange name. Maybe "perusskenaario"?](https://app.asana.com/1/1201243246741462/project/1209894780050709/task/1211125688251887?focus=true)

<img width="496" height="99" alt="image" src="https://github.com/user-attachments/assets/2f33bc77-939b-460c-875c-e41ae3be4ec4" />

<img width="596" height="72" alt="image" src="https://github.com/user-attachments/assets/7d8d238e-b5a5-4ae4-a9b9-bb3e7116c39d" />

<img width="534" height="72" alt="image" src="https://github.com/user-attachments/assets/7c22aa1b-ce37-48a5-8dbb-dc03693ca4f2" />
