### PR TITLE
Fix/outcome drilldown and slug

### DIFF
--- a/src/components/general/OutcomeBlock.tsx
+++ b/src/components/general/OutcomeBlock.tsx
@@ -70,20 +70,23 @@ const OutcomeBlock = (props: OutcomeBlockProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
   useEffect(() => {
-    if (router.query?.node === lastActiveNodeId) return;
-    const query: ParsedUrlQuery = {};
-    if (lastActiveNodeId) {
-      query.node = lastActiveNodeId;
-    }
+    if (!router.isReady) return;
+    
+    const currentNode =
+      Array.isArray(router.query.node) ? router.query.node[0] : router.query.node;
+    if (currentNode === lastActiveNodeId) return;
+    
+    const nextQuery: ParsedUrlQuery = { ...router.query };
+    if (lastActiveNodeId) nextQuery.node = lastActiveNodeId;
+    else delete nextQuery.node;
+
     void router.replace(
-      {
-        query,
-      },
+      { pathname: router.pathname, query: nextQuery },
       undefined,
       { shallow: true }
     );
-  }, [lastActiveNodeId, router]);
-
+  }, [lastActiveNodeId, router.isReady, router.pathname, router.query]);
+    
   if (loading || !outcomeNode) {
     return <OutcomeBlockLoader />;
   }

--- a/src/components/general/OutcomeBlock.tsx
+++ b/src/components/general/OutcomeBlock.tsx
@@ -42,16 +42,19 @@ const OutcomeBlockLoader = () => {
 
 const findVisibleNodes = (
   allNodes: Map<string, OutcomeNodeFieldsFragment>,
-  lastNodeId: string,
-  visibleNodes: OutcomeNodeFieldsFragment[]
+  startNodeId: string,
+  visibleNodes: OutcomeNodeFieldsFragment[],
+  visited = new Set<string>()
 ) => {
-  // Using last active node Id, create an array of all visible nodes
-  const lastNode = allNodes.get(lastNodeId)!;
-  visibleNodes.unshift(lastNode);
-  if (lastNode.outputNodes?.length) {
-    if (!allNodes.has(lastNode.outputNodes[0].id)) return visibleNodes;
-    findVisibleNodes(allNodes, lastNode.outputNodes[0].id, visibleNodes);
-  }
+  const node = allNodes.get(startNodeId)!;
+  if (!node || visited.has(startNodeId)) return visibleNodes;
+  visited.add(startNodeId);
+
+  // Prepend so parent is displayed before children
+  visibleNodes.unshift(node);
+  const outputs = node.outputNodes?.map((n) => n.id) ?? [];
+  const parentId = outputs.find((id) => allNodes.has(id));
+  if (parentId) return findVisibleNodes(allNodes, parentId, visibleNodes, visited);
   return visibleNodes;
 };
 
@@ -71,7 +74,7 @@ const OutcomeBlock = (props: OutcomeBlockProps) => {
   const { t } = useTranslation();
   useEffect(() => {
     if (!router.isReady) return;
-    
+
     const currentNode =
       Array.isArray(router.query.node) ? router.query.node[0] : router.query.node;
     if (currentNode === lastActiveNodeId) return;


### PR DESCRIPTION
Fix child outcome graph drill-down and slug interpolation error.
More details and the test case in the Asana - https://app.asana.com/1/1201243246741462/project/1205310117865974/task/1211241718546917?focus=true

* Got ```Next.js``` error while running Outcome page locally (the error doesn't appear in prod): ```The provided `href` (/[...slug]?node=i4_city_administration_emissions) value is missing query values (slug) to be interpolated properly. ```
Applied ```router.isReady``` to fix the error to be able to proceed with the initial task.

* Drill-down fix: In some cases child outcome graph replaces the main graph. Updated  ```findVisibleNodes``` : pick the parent that exists in ```allNodes ```(not always ```outputNodes[0]```), prevent loops, display child graph below the parent (not replace it).


https://github.com/user-attachments/assets/061d0b59-debe-4331-b785-a2e0318d77d8



