### PR TITLE
Handle referenceYear before start year

### DIFF
--- a/src/components/general/DimensionalNodeVisualisation.tsx
+++ b/src/components/general/DimensionalNodeVisualisation.tsx
@@ -158,7 +158,6 @@ export default function DimensionalNodeVisualisation({
   // And user has selected the reference year as the start year of the chart
   const showReferenceYear =
     !!instance?.referenceYear &&
-    startYear === instance.referenceYear &&
     instance.referenceYear !== instance.minimumHistoricalYear;
   const referenceYear = showReferenceYear ? instance.referenceYear : undefined;
 


### PR DESCRIPTION
Tampere-c4c was missing the reference-year bar (1990), while the old Paths UI showed a separate bar when the years range begins later (2010). 
Asana - https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1211356374050860?focus=true
<img width="586" height="229" alt="old_paths" src="https://github.com/user-attachments/assets/1d16edaa-2e7e-4704-bfeb-34cd94e52f81" />

Handle the cases when the reference year for the plan is set to some year before the start year (```minimumHistoricYear```), like in ```tampere-c4c```.
* Removed the blocker ```startYear === instance.referenceYear``` from the ```showReferenceYear```.
* This change reproduces the legacy Paths and doesn’t affect other instances behaviour.

<img width="1141" height="416" alt="tampere-new" src="https://github.com/user-attachments/assets/bdfdd442-d25b-40d4-907a-16d472096413" />


