### PR TITLE
Make scenario panel sticky

### DIFF
--- a/src/common/mui-theme/components.ts
+++ b/src/common/mui-theme/components.ts
@@ -38,6 +38,9 @@ export function getComponents(theme: Theme): ThemeOptions['components'] {
             boxShadow: `0 0 0 0.25rem ${theme.inputBtnFocusColor}`,
           },
         },
+        sizeSmall: {
+          lineHeight: theme.lineHeightSm,
+        },
         contained: {
           '&:hover': {
             boxShadow: 'none',

--- a/src/common/mui-theme/theme.ts
+++ b/src/common/mui-theme/theme.ts
@@ -26,6 +26,35 @@ export function initializeMuiTheme(theme: BaseTheme): MuiTheme {
   muiTheme = {
     ...theme,
     ...createTheme({
+      // Shadows are modified from the MUI base theme (https://mui.com/material-ui/customization/default-theme/)
+      // simply reducing the opacity
+      shadows: [
+        'none',
+        '0px 2px 1px -1px rgba(0,0,0,0.08), 0px 1px 1px 0px rgba(0,0,0,0.06), 0px 1px 3px 0px rgba(0,0,0,0.05)',
+        '0px 3px 1px -2px rgba(0,0,0,0.08), 0px 2px 2px 0px rgba(0,0,0,0.06), 0px 1px 5px 0px rgba(0,0,0,0.05)',
+        '0px 3px 3px -2px rgba(0,0,0,0.08), 0px 3px 4px 0px rgba(0,0,0,0.06), 0px 1px 8px 0px rgba(0,0,0,0.05)',
+        '0px 2px 4px -1px rgba(0,0,0,0.08), 0px 4px 5px 0px rgba(0,0,0,0.06), 0px 1px 10px 0px rgba(0,0,0,0.05)',
+        '0px 3px 5px -1px rgba(0,0,0,0.08), 0px 5px 8px 0px rgba(0,0,0,0.06), 0px 1px 14px 0px rgba(0,0,0,0.05)',
+        '0px 3px 5px -1px rgba(0,0,0,0.08), 0px 6px 10px 0px rgba(0,0,0,0.06), 0px 1px 18px 0px rgba(0,0,0,0.05)',
+        '0px 4px 5px -2px rgba(0,0,0,0.08), 0px 7px 10px 1px rgba(0,0,0,0.06), 0px 2px 16px 1px rgba(0,0,0,0.05)',
+        '0px 5px 5px -3px rgba(0,0,0,0.08), 0px 8px 10px 1px rgba(0,0,0,0.06), 0px 3px 14px 2px rgba(0,0,0,0.05)',
+        '0px 5px 6px -3px rgba(0,0,0,0.08), 0px 9px 12px 1px rgba(0,0,0,0.06), 0px 3px 16px 2px rgba(0,0,0,0.05)',
+        '0px 6px 6px -3px rgba(0,0,0,0.08), 0px 10px 14px 1px rgba(0,0,0,0.06), 0px 4px 18px 3px rgba(0,0,0,0.05)',
+        '0px 6px 7px -4px rgba(0,0,0,0.08), 0px 11px 15px 1px rgba(0,0,0,0.06), 0px 4px 20px 3px rgba(0,0,0,0.05)',
+        '0px 7px 8px -4px rgba(0,0,0,0.08), 0px 12px 17px 2px rgba(0,0,0,0.06), 0px 5px 22px 4px rgba(0,0,0,0.05)',
+        '0px 7px 8px -4px rgba(0,0,0,0.08), 0px 13px 19px 2px rgba(0,0,0,0.06), 0px 5px 24px 4px rgba(0,0,0,0.05)',
+        '0px 7px 9px -4px rgba(0,0,0,0.08), 0px 14px 21px 2px rgba(0,0,0,0.06), 0px 5px 26px 4px rgba(0,0,0,0.05)',
+        '0px 8px 9px -5px rgba(0,0,0,0.08), 0px 15px 22px 2px rgba(0,0,0,0.06), 0px 6px 28px 5px rgba(0,0,0,0.05)',
+        '0px 8px 10px -5px rgba(0,0,0,0.08), 0px 16px 24px 2px rgba(0,0,0,0.06), 0px 6px 30px 5px rgba(0,0,0,0.05)',
+        '0px 8px 11px -5px rgba(0,0,0,0.08), 0px 17px 26px 2px rgba(0,0,0,0.06), 0px 6px 32px 5px rgba(0,0,0,0.05)',
+        '0px 9px 11px -5px rgba(0,0,0,0.08), 0px 18px 28px 2px rgba(0,0,0,0.06), 0px 7px 34px 6px rgba(0,0,0,0.05)',
+        '0px 9px 12px -6px rgba(0,0,0,0.08), 0px 19px 29px 2px rgba(0,0,0,0.06), 0px 7px 36px 6px rgba(0,0,0,0.05)',
+        '0px 10px 13px -6px rgba(0,0,0,0.08), 0px 20px 31px 3px rgba(0,0,0,0.06), 0px 8px 38px 7px rgba(0,0,0,0.05)',
+        '0px 10px 13px -6px rgba(0,0,0,0.08), 0px 21px 33px 3px rgba(0,0,0,0.06), 0px 8px 40px 7px rgba(0,0,0,0.05)',
+        '0px 10px 14px -6px rgba(0,0,0,0.08), 0px 22px 35px 3px rgba(0,0,0,0.06), 0px 8px 42px 7px rgba(0,0,0,0.05)',
+        '0px 11px 14px -7px rgba(0,0,0,0.08), 0px 23px 36px 3px rgba(0,0,0,0.06), 0px 9px 44px 8px rgba(0,0,0,0.05)',
+        '0px 11px 15px -7px rgba(0,0,0,0.08), 0px 24px 38px 3px rgba(0,0,0,0.06), 0px 9px 46px 8px rgba(0,0,0,0.05)',
+      ],
       palette: getPalette(theme),
       typography: getTypography(theme),
       shape: {

--- a/src/components/common/MuiThemeExample.tsx
+++ b/src/components/common/MuiThemeExample.tsx
@@ -9,6 +9,7 @@ import {
   Chip,
   FormControl,
   FormControlLabel,
+  Grid,
   InputLabel,
   MenuItem,
   Select,
@@ -201,9 +202,13 @@ export function MuiThemeExample() {
 
         {/* Colors */}
         <Box>
+          <Typography variant="h3" gutterBottom>
+            Colours
+          </Typography>
+
           <Stack spacing={1}>
             <Box>
-              <Typography variant="h3" gutterBottom>
+              <Typography variant="h4" gutterBottom>
                 Primary
               </Typography>
               <Stack direction="row" flexWrap="wrap">
@@ -214,7 +219,7 @@ export function MuiThemeExample() {
               </Stack>
             </Box>
             <Box>
-              <Typography variant="h3" gutterBottom>
+              <Typography variant="h4" gutterBottom>
                 Secondary
               </Typography>
               <Stack direction="row" flexWrap="wrap">
@@ -225,6 +230,23 @@ export function MuiThemeExample() {
               </Stack>
             </Box>
           </Stack>
+        </Box>
+
+        {/* Shadows */}
+        <Box>
+          <Typography variant="h3" gutterBottom>
+            Shadows
+          </Typography>
+
+          <Grid container spacing={2}>
+            {Array(20)
+              .fill(undefined)
+              .map((_, index) => (
+                <Grid key={index}>
+                  <Box sx={{ width: 100, height: 100, boxShadow: index, p: 2 }}>{index}</Box>
+                </Grid>
+              ))}
+          </Grid>
         </Box>
       </Stack>
     </Box>

--- a/src/components/scenario/ScenarioPanel.tsx
+++ b/src/components/scenario/ScenarioPanel.tsx
@@ -162,7 +162,7 @@ const ScenarioPanel = () => {
       <Box
         sx={{
           zIndex: 1,
-          boxShadow: 3,
+          boxShadow: 2,
           ...(isPanelFixed ? FIXED_STYLES : RELATIVE_STYLES),
           // Background overlay so that the panel stretches to the full window width while fixed
           '&::after': {

--- a/src/components/scenario/ScenarioPanel.tsx
+++ b/src/components/scenario/ScenarioPanel.tsx
@@ -1,6 +1,17 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+
 import { gql, useQuery, useReactiveVar } from '@apollo/client';
 import { useTheme } from '@emotion/react';
-import { Box, Button, Grid, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Collapse,
+  Container,
+  Grid,
+  Typography,
+  useMediaQuery,
+  useScrollTrigger,
+} from '@mui/material';
 import { useTranslation } from 'next-i18next';
 import { Sliders } from 'react-bootstrap-icons';
 
@@ -38,8 +49,77 @@ export const GET_INSTANCE_GOAL_OUTCOME = gql`
   }
 `;
 
+/**
+ * Determines if the scenario panel is fixed and if its minimized.
+ * The minimized version shows the scenario selector and edit scenario button,
+ * hiding the title and year selectors.
+ *
+ * The panel sticks upon scroll past the initial relative position. We display the
+ * full panel when scrolling up, and the minimized version when scrolling down.
+ *
+ * Also return the initial height of the relative panel to support rendering a
+ * placeholder when the panel is fixed and prevent content jumping.
+ */
+function useIsPanelStuck(ref) {
+  const theme = useTheme();
+  const [position, setPosition] = useState({ top: 0, initialHeight: 0 });
+  const isScrollingDown = useScrollTrigger();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const hasScrolledPastPanelStart = useScrollTrigger({
+    disableHysteresis: true,
+    threshold: position.top,
+  });
+  const hasScrolledPastPanelEnd = useScrollTrigger({
+    disableHysteresis: true,
+    threshold: position.top + position.initialHeight,
+  });
+
+  const isPanelFixed = !isMobile && hasScrolledPastPanelStart;
+  const isPanelMini = isScrollingDown && isPanelFixed && hasScrolledPastPanelEnd;
+
+  function handleChangePosition() {
+    if (ref.current) {
+      setPosition((position) => ({
+        ...position,
+        top: ref.current.getBoundingClientRect().top + window.pageYOffset,
+      }));
+    }
+  }
+
+  useLayoutEffect(() => {
+    if (ref.current) {
+      setPosition({
+        top: ref.current.getBoundingClientRect().top + window.pageYOffset,
+        initialHeight: ref.current.getBoundingClientRect().height,
+      });
+    }
+
+    window.addEventListener('resize', handleChangePosition);
+
+    return () => {
+      window.removeEventListener('resize', handleChangePosition);
+    };
+  }, [ref]);
+
+  return { isPanelFixed, isPanelMini, initialHeight: position.initialHeight };
+}
+
+const FIXED_STYLES = {
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  zIndex: 1000,
+};
+
+const RELATIVE_STYLES = {
+  position: 'relative',
+};
+
 const ScenarioPanel = () => {
   const theme = useTheme();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { isPanelFixed, isPanelMini, initialHeight } = useIsPanelStuck(containerRef);
   const { t } = useTranslation();
   const [site] = useSiteWithSetter();
   const instance = useInstance();
@@ -76,71 +156,113 @@ const ScenarioPanel = () => {
       .map((value) => value.year) ?? [];
 
   return (
-    <Box sx={{ boxShadow: 2 }}>
-      <Box sx={{ p: 1, backgroundColor: theme.graphColors.blue010 }}>
-        <Typography variant="h4" sx={{ lineHeight: 1, m: 0, p: 0, mb: 1 }}>
-          {t('scenario')}
-        </Typography>
-        <Grid container spacing={2} sx={{ alignItems: 'flex-end' }}>
-          <Grid size={{ xs: 12, md: 6 }}>
-            <Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 1 }}>
-              <ScenarioSelector />
-              <Button
-                size="small"
-                color="primary"
-                onClick={handleEditClick}
-                startIcon={<Sliders />}
-              >
-                {t('edit-scenario')}
-              </Button>
-            </Box>
-          </Grid>
-          {nrGoals > 1 && (
-            <Grid size={{ xs: 12, md: 6 }}>
-              <GoalSelector />
-            </Grid>
-          )}
-          {activeGoal && data?.instance?.goals?.[0] && (
-            <Grid size={{ xs: 12, md: 6 }}>
-              <ScenarioOutcome
-                goalOutcome={data?.instance?.goals?.[0]}
-                activeGoal={activeGoal}
-                targetYear={yearRange[1]}
-                variant="compact"
-              />
-            </Grid>
-          )}
-        </Grid>
-      </Box>
+    <div ref={containerRef}>
+      {/* Placeholder to avoid content shifting when the panel is fixed */}
+      {isPanelFixed && <Box sx={{ height: initialHeight, visibility: 'hidden' }} />}
       <Box
         sx={{
-          display: 'flex',
-          flexDirection: 'row',
-          alignItems: 'center',
-          gap: 1,
-          p: 1,
-          backgroundColor: theme.graphColors.grey010,
-          [theme.breakpoints.down('md')]: {
-            flexDirection: 'column',
-            alignItems: 'flex-start',
-            gap: 0.5,
+          zIndex: 1,
+          boxShadow: 3,
+          ...(isPanelFixed ? FIXED_STYLES : RELATIVE_STYLES),
+          // Background overlay so that the panel stretches to the full window width while fixed
+          '&::after': {
+            content: '""',
+            position: 'absolute',
+            opacity: isPanelFixed ? 1 : 0,
+            transition: isPanelFixed
+              ? 'opacity 0.2s, transform 0.1s'
+              : 'opacity 0.2s, transform 0s 0.2s',
+            transform: isPanelFixed ? 'scaleX(1)' : 'scaleX(0.8)',
+            transformOrigin: 'center',
+            top: 0,
+            left: '50%',
+            marginLeft: '-50vw',
+            width: '100vw',
+            zIndex: -1,
+            height: '100%',
+            backgroundColor: theme.graphColors.blue010,
           },
         }}
       >
-        <Typography variant="h6" sx={{ lineHeight: 1, m: 0, p: 0 }}>
-          {t('display')}:
-        </Typography>
+        <Container fixed maxWidth="xl" disableGutters={!isPanelFixed}>
+          <Box sx={{ p: 1, backgroundColor: theme.graphColors.blue010 }}>
+            <Collapse
+              key={isPanelFixed ? 'fixed' : 'relative'}
+              appear={false}
+              in={!isPanelFixed || !isPanelMini}
+            >
+              <Typography variant="h4" sx={{ lineHeight: 1, m: 0, p: 0, mb: 1 }}>
+                {t('scenario')}
+              </Typography>
+            </Collapse>
+            <Grid container spacing={2} sx={{ alignItems: 'flex-end' }}>
+              <Grid size={{ xs: 12, md: 6 }}>
+                <Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 1 }}>
+                  <ScenarioSelector />
+                  <Button
+                    size="small"
+                    color="primary"
+                    onClick={handleEditClick}
+                    startIcon={<Sliders />}
+                  >
+                    {t('edit-scenario')}
+                  </Button>
+                </Box>
+              </Grid>
+              {nrGoals > 1 && (
+                <Grid size={{ xs: 12, md: 6 }}>
+                  <GoalSelector />
+                </Grid>
+              )}
+              {activeGoal && data?.instance?.goals?.[0] && (
+                <Grid size={{ xs: 12, md: 6 }}>
+                  <ScenarioOutcome
+                    goalOutcome={data?.instance?.goals?.[0]}
+                    activeGoal={activeGoal}
+                    targetYear={yearRange[1]}
+                    variant="compact"
+                  />
+                </Grid>
+              )}
+            </Grid>
+          </Box>
+          <Collapse
+            key={isPanelFixed ? 'fixed' : 'relative'}
+            appear={false}
+            in={!isPanelFixed || !isPanelMini}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: 1,
+                p: 1,
+                backgroundColor: theme.graphColors.grey010,
+                [theme.breakpoints.down('md')]: {
+                  flexDirection: 'column',
+                  alignItems: 'flex-start',
+                  gap: 0.5,
+                },
+              }}
+            >
+              <Typography variant="h6" sx={{ lineHeight: 1, m: 0, p: 0 }}>
+                {t('display')}:
+              </Typography>
 
-        <YearRangeSelector
-          minYear={minYear}
-          maxYear={maxYear}
-          maxHistoricalYear={maxHistoricalYear}
-          yearsWithGoals={yearsWithGoals}
-        />
+              <YearRangeSelector
+                minYear={minYear}
+                maxYear={maxYear}
+                maxHistoricalYear={maxHistoricalYear}
+                yearsWithGoals={yearsWithGoals}
+              />
 
-        {availableNormalizations.length > 0 && <NormalizationWidget />}
+              {availableNormalizations.length > 0 && <NormalizationWidget />}
+            </Box>
+          </Collapse>
+        </Container>
       </Box>
-    </Box>
+    </div>
   );
 };
 

--- a/src/components/scenario/ScenarioPanel.tsx
+++ b/src/components/scenario/ScenarioPanel.tsx
@@ -60,7 +60,7 @@ export const GET_INSTANCE_GOAL_OUTCOME = gql`
  * Also return the initial height of the relative panel to support rendering a
  * placeholder when the panel is fixed and prevent content jumping.
  */
-function useIsPanelStuck(ref) {
+function useIsPanelStuck(ref: React.RefObject<HTMLDivElement | null>) {
   const theme = useTheme();
   const [position, setPosition] = useState({ top: 0, initialHeight: 0 });
   const isScrollingDown = useScrollTrigger();
@@ -81,7 +81,7 @@ function useIsPanelStuck(ref) {
     if (ref.current) {
       setPosition((position) => ({
         ...position,
-        top: ref.current.getBoundingClientRect().top + window.pageYOffset,
+        top: ref.current?.getBoundingClientRect().top ?? position.top + window.pageYOffset,
       }));
     }
   }


### PR DESCRIPTION
## Description
Make the scenario selector panel sticky so that:
1. When scrolling past the top of the scenario panel it sticks to the top of the window
2. When scrolling down after passing the panel, the fixed version minimises to collapse the title and year selectors
3. When scrolling up after passing the panel, the fixed version expands the title and year selectors

On mobile, the panel always remains relatively positioned to avoid taking space on a smaller screen.

Includes some funky CSS to ensure a smooth transition between different states.

Also:
- Reduce the line height of small MUI buttons.
- Update the base theme shadows to reduce the opacity, previous shadows felt very heavy.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related issue
[🎟️ Asana ticket](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1211450868191931?focus=true)

## Requirements, dependencies and related PRs
N/A

------

## ✅ Pre-Merge Checklist

### Testing
- [x] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)

### Internationalization & Accessibility
- [x] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [x] **Dependencies are merged** (if applicable. If the change depends on other PR's e.g. paths backend)

-----

## Screenshots/Videos (if applicable)

https://github.com/user-attachments/assets/61a5132b-386a-4348-8757-a3e764ef1f1b

