### PR TITLE
Fix/cost benefit use db action name

### DIFF
--- a/src/components/general/CostBenefitAnalysis.tsx
+++ b/src/components/general/CostBenefitAnalysis.tsx
@@ -70,7 +70,7 @@ function getChartData(data: Cubes[], theme: Theme, t: TFunction): EChartsCoreOpt
       ],
       source: sortedData.map((item) => {
         return {
-          action: item.actionName || item.metric.data.name || '',
+          action: item.actionName,
           cost: item.totals.cost,
           benefit: item.totals.benefit,
           netBenefit: item.totals.netBenefit,
@@ -202,14 +202,14 @@ export function CostBenefitAnalysis({ data, isLoading }: Props) {
     );
 
     if (!costBenefitData) {
-      return [];
+      return [] as { metric: DimensionalMetric; actionName: string }[];
     }
 
     return costBenefitData.actions
       .map((action) => {
         if (!action?.effectDim) return undefined;
         const metric = new DimensionalMetric(action.effectDim);
-        const actionName = action.action?.name ?? metric.data?.name ?? '';
+        const actionName = action.action?.name ?? '';
         if (!actionName) return undefined;
         return { metric, actionName };
       })


### PR DESCRIPTION
## Description
Fixes the cost–benefit visualization showing `yaml` metric names instead of DB action names.
If an action name is updated via the Paths admin, this is not reflected in the cost-benefit visualization.

Use `action.action.name` for y-axis actions labels (admin value).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related issue
Asana https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1211241718546910?focus=true

## Screenshots/Videos (if applicable)
Before (yaml action names):
<img width="1295" height="675" alt="yaml-actions" src="https://github.com/user-attachments/assets/2d621aa0-dce7-4c57-b5ea-5c5a479384a0" />


After (Admin action names)
<img width="1136" height="661" alt="admin-actions" src="https://github.com/user-attachments/assets/069aafd9-5e27-43cc-9542-0e27a061030c" />

The same fix will be applied to the `main` branch.




