### PR TITLE
Add AGENTS.md for Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+This is a **single-product frontend-only** repository (Kausal Paths UI — a Next.js 15 app). The only external dependency is the Kausal Paths Django/GraphQL backend; a public dev API at `https://api.paths.kausal.dev` is used by default so no local backend setup is needed.
+
+### Running the dev server
+
+See `CLAUDE.md` and `README.md` for standard commands (`pnpm dev`, `pnpm build`, quality checks, etc.).
+
+Key caveats:
+
+- The `kausal_common` git submodule **must** be initialized (`git submodule update --init`) before any build or dev command will work — configs like `eslint.config.mjs`, `next.config.ts`, and `prettier.config.mjs` import from it.
+- The app uses multi-instance hostname routing. In local dev, `WILDCARD_DOMAINS` defaults to `localhost`. Access the app via `http://sunnydale.localhost:3000` (or another valid instance subdomain). A plain `http://localhost:3000` request will return a 404 because no instance matches.
+- `@kausal-private/themes-private` is in `optionalDependencies` and may or may not be available. The app falls back to public themes and works fine without it.
+
+### Quality checks
+
+- `pnpm lint:baseline` — ESLint (baseline-suppressed; only new errors surface)
+- `pnpm typecheck:baseline` — TypeScript (baseline-suppressed; only new errors surface)
+- `pnpm prettier:fix` — format all files
+
+### Node version
+
+`.nvmrc` specifies Node 25. Use `nvm use` (after `nvm install 25` if needed). pnpm 10 is managed via corepack (`corepack enable`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Add `AGENTS.md` with Cursor Cloud specific instructions for autonomous development environment setup. This documents key caveats and non-obvious setup requirements for cloud agents working on this codebase.

## Screenshots/Videos (if applicable)
N/A — documentation-only change.

## Related issue
N/A — development environment setup task.

## Requirements, dependencies and related PRs
None.

## Additional Notes
The `AGENTS.md` file captures important learnings for cloud agent sessions:
- `kausal_common` git submodule must be initialized before any build/dev command
- Multi-instance hostname routing requires accessing via `<instance>.localhost:3000` (e.g., `tampere.localhost:3000`)
- `@kausal-private/themes-private` is optional; the app falls back to public themes
- Quality check commands use baseline suppression (`pnpm lint:baseline`, `pnpm typecheck:baseline`)
- Node 25 (per `.nvmrc`) with pnpm 10 via corepack

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    No manual testing needed — documentation-only change.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. paths backend)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de36973e-54d1-40c7-b92c-2b86a29ded26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de36973e-54d1-40c7-b92c-2b86a29ded26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

