### PR TITLE
Add keyboard focus to action impact chart

### DIFF
--- a/src/components/general/resident-dashboard/DashboardVisualizationActionImpact.tsx
+++ b/src/components/general/resident-dashboard/DashboardVisualizationActionImpact.tsx
@@ -259,6 +259,17 @@ const DashboardVisualizationActionImpact = ({ actions, chartLabel, unit }: Props
             <OverlayScrollbarsComponent
               defer
               className="os-top-scrollbar"
+              role="region"
+              aria-label={chartLabel}
+              events={{
+                initialized(instance) {
+                  const viewport = instance.elements().viewport;
+                  viewport.setAttribute('tabindex', '0');
+                  if (chartLabel) {
+                    viewport.setAttribute('aria-label', chartLabel);
+                  }
+                },
+              }}
               options={{
                 scrollbars: { autoHide: 'never' },
                 overflow: { x: 'scroll', y: 'hidden' },


### PR DESCRIPTION
## Description
Fix an accessibility issue in the action impact chart scroll area detected by axeDevtools: `Scrollable region must have keyboard access`.
* Make the scrollable viewport focusable with `tabindex="0"`.
* Keep `OverlayScrollbarsComponent` and only improve keyboard accessibility.
* Add `aria-label`

## Screenshots/Videos (if applicable)
before:
<img width="1470" height="632" alt="Screenshot 2026-04-15 at 14 00 26" src="https://github.com/user-attachments/assets/c05fe419-7ddf-4092-aa4e-fc16a25a29ac" />

After:
<img width="1470" height="532" alt="Screenshot 2026-04-15 at 14 00 57" src="https://github.com/user-attachments/assets/39696dff-6e21-4d08-bdd4-47926e2172ad" />


## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here


## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. paths backend)
