### PR TITLE
Adapt app to updated kausal_common

### DIFF
--- a/configs/tsconfig.next.json
+++ b/configs/tsconfig.next.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "../kausal_common/configs/tsconfig.react.json",
+  "extends": "../kausal_common/configs/tsconfig.json",
   "compilerOptions": {
     "jsx": "preserve",
     "paths": {

--- a/configs/tsconfig.node.json
+++ b/configs/tsconfig.node.json
@@ -1,10 +1,11 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "../kausal_common/configs/tsconfig.node.base.json",
+  "extends": "../kausal_common/configs/tsconfig.json",
   "include": [
     "../*.ts",
     "../*.js",
     "../kausal_common/configs/*.ts",
+    "../kausal_common/configs/*.mjs",
     "../kausal_common/scripts/*.js"
   ],
   "compilerOptions": {

--- a/e2e-tests/tsconfig.json
+++ b/e2e-tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../kausal_common/configs/tsconfig.base.json",
+  "extends": "../kausal_common/configs/tsconfig.json",
   "compilerOptions": {
     "paths": {
       "@common/*": ["../kausal_common/src/*"],

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,25 +1,9 @@
 import { defineConfig, globalIgnores } from 'eslint/config';
-import type { ConfigWithExtends } from 'typescript-eslint';
 
-import {
-  getGlobalIgnores,
-  getGraphQLDocsConfig,
-  getGraphQLProcessorConfig,
-  getNextEslintConfig,
-  getNodeConfig,
-} from './kausal_common/configs/eslint.ts';
+import { getEslintConfig } from './kausal_common/configs/eslint.mjs';
 
-const nodeConfig = getNodeConfig({
-  dirs: ['kausal_common/configs'],
-  files: ['*.ts', '*.js', 'kausal_common/scripts/*.js'],
-});
-const nextConfig = await getNextEslintConfig(['src', 'kausal_common/src']);
-const config: ConfigWithExtends[] = defineConfig(
-  getGraphQLProcessorConfig({ jsDirs: ['src', 'kausal_common/src'] }),
-  getGraphQLDocsConfig(['src', 'kausal_common/src']),
-  nextConfig,
-  nodeConfig,
-  getGlobalIgnores(),
+const config = defineConfig(
+  ...(await getEslintConfig(import.meta.dirname)),
   globalIgnores(
     ['kausal_common/src/components/paths', 'kausal_common/src/utils/paths'],
     'no-patchenstein'

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,7 @@ import withNextIntl from 'next-intl/plugin';
 import type { Options as SassOptions } from 'sass';
 
 import { getNextConfig } from './kausal_common/configs/common-next-config.ts';
-import { wrapWithSentryConfig } from './kausal_common/configs/sentry-next-config.ts';
+import { wrapWithSentryConfig } from './kausal_common/src/sentry/sentry-next-config.ts';
 import { initializeThemes } from './kausal_common/src/themes/next-config.mjs';
 
 process.env.NEXT_TELEMETRY_DISABLED = '1';

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -1,6 +1,6 @@
 import { type Config } from 'prettier';
 
-import defaultConfig from './kausal_common/configs/prettier.ts';
+import defaultConfig from './kausal_common/configs/prettier.mjs';
 
 const config = {
   ...defaultConfig,

--- a/src/common/apollo-config.ts
+++ b/src/common/apollo-config.ts
@@ -4,7 +4,7 @@ import type { Logger } from 'pino';
 
 import type { DefaultApolloContext } from '@common/apollo';
 import { type DirectiveArg, createOperationDirective } from '@common/apollo/directives';
-import { createSentryLink, logOperationLink, retryLink } from '@common/apollo/links';
+import { createSentryLink, logOperationLink } from '@common/apollo/links';
 import { FORWARDED_HEADER } from '@common/constants/headers.mjs';
 import { GRAPHQL_CLIENT_PROXY_PATH } from '@common/constants/routes.mjs';
 import { getPathsGraphQLUrl, getRuntimeConfig } from '@common/env';
@@ -225,7 +225,6 @@ export function getApolloClientConfig(opts: ApolloClientOpts): {
 
   return {
     link: ApolloLink.from([
-      retryLink,
       createSentryLink(uri),
       logOperationLink,
       localeMiddleware,

--- a/src/middleware/context.ts
+++ b/src/middleware/context.ts
@@ -4,11 +4,11 @@ import { ApolloClient, ApolloLink, HttpLink, InMemoryCache, gql } from '@apollo/
 import * as Sentry from '@sentry/nextjs';
 import type { Logger } from 'pino';
 
-import { createSentryLink, logOperationLink, retryLink } from '@common/apollo/links';
+import { createSentryLink, logOperationLink } from '@common/apollo/links';
 import { getPathsGraphQLUrl } from '@common/env';
 import { envToBool } from '@common/env/utils';
+import LRUCache from '@common/utils/lru-cache';
 import { getClientIP } from '@common/utils';
-import { SWRCache } from '@common/utils/swr-cache';
 
 import type {
   AvailableInstanceFragment,
@@ -59,7 +59,6 @@ function createApolloClient(req: NextRequest, logger: Logger) {
     ssrMode: false,
 
     link: ApolloLink.from([
-      retryLink,
       logOperationLink,
       createSentryLink(uri),
       new ApolloLink((operation, forward) => {
@@ -122,8 +121,13 @@ async function fetchInstances(hostname: string, { req, logger }: InstanceFetchCt
   });
 }
 
-const instanceCache = new SWRCache<string, AvailableInstanceFragment[], InstanceFetchCtx>({
-  fetcher: fetchInstances,
+const instanceCache = new LRUCache<string, AvailableInstanceFragment[]>({
+  upsert: async (hostname, args) => {
+    const [ctx] = args as [InstanceFetchCtx];
+    const value = await fetchInstances(hostname, ctx);
+    return { value };
+  },
+  onEvict: () => {},
   ttl: 2_000,
 });
 
@@ -132,5 +136,5 @@ export async function getInstancesForRequest(req: NextRequest, hostname: string,
   if (disableInstanceCache) {
     return fetchInstances(hostname, ctx);
   }
-  return instanceCache.get(hostname, ctx);
+  return instanceCache.upsert(hostname, ctx);
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -13,7 +13,7 @@ import {
 import { HEALTH_CHECK_PUBLIC_PATH } from '@common/constants/routes.mjs';
 import { getDeploymentType, getSpotlightUrl, getWildcardDomains, isLocalDev } from '@common/env';
 import { envToBool } from '@common/env/utils';
-import { getTraceLogBindings } from '@common/logging/init';
+import { getSpanContext } from '@common/logging/init';
 import { LOGGER_CORRELATION_ID, generateCorrelationID, getLogger } from '@common/logging/logger';
 
 import { ensureSlash, splitPath } from '@/utils/paths';
@@ -161,7 +161,7 @@ function getLoggerForRequest(req: NextRequest, host: string, path: string) {
   const span = Sentry.getActiveSpan();
   const spanBindings: Bindings = {};
   if (span) {
-    Object.assign(spanBindings, getTraceLogBindings());
+    Object.assign(spanBindings, getSpanContext());
     if (OTEL_DEBUG) {
       spanBindings['sampled'] = span.isRecording();
     }

--- a/stories/tsconfig.json
+++ b/stories/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../kausal_common/configs/tsconfig.base.json",
+  "extends": "../kausal_common/configs/tsconfig.json",
   "compilerOptions": {
     "moduleResolution": "bundler",
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "files": [],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@common/*": ["kausal_common/src/*"]
+    }
+  },
   "references": [
     { "path": "./configs/tsconfig.next.json" },
     { "path": "./configs/tsconfig.node.json" }


### PR DESCRIPTION
Update the app-level config and integration code to match the newer kausal_common structure and APIs. This switches imports to the new shared entry points, restores root path alias resolution for Next and Turbopack, replaces removed cache and logging helpers, and aligns the middleware and Apollo setup so the app runs against the upgraded shared package.

This has been vibe-coded and I don't really know what I'm doing, so please check. 😬 The goal was to make the current KP UI work with the latest version of this repo.

## Related issue
[kausal-ui-common PR](https://github.com/kausaltech/kausal-ui-common/pull/18)

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. paths backend)
