### PR TITLE
Add nofollow to Paths UI robots directive

### DIFF
--- a/src/app/root/[domain]/[lang]/layout.tsx
+++ b/src/app/root/[domain]/[lang]/layout.tsx
@@ -140,7 +140,7 @@ export async function generateMetadata(props: LayoutProps): Promise<Metadata> {
   const theme = await loadTheme(data.instance.themeIdentifier || 'default');
 
   return {
-    robots: 'noindex',
+    robots: 'noindex, nofollow',
     title: data.instance.name,
     description: data.instance.leadParagraph,
     openGraph: {


### PR DESCRIPTION
## Description
Add nofollow to Paths UI robots directive
Indexing was already blocked via `noindex` on the root layout, but `follow` was left at its default. 
Adding `nofollow` ensures crawlers that do reach a Paths page don't traverse its links onward either.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here


## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. paths backend)
