### PR TITLE
Fix late error handling

### DIFF
--- a/src/app/root/[domain]/[lang]/(with-layout)/actions/[slug]/page.tsx
+++ b/src/app/root/[domain]/[lang]/(with-layout)/actions/[slug]/page.tsx
@@ -174,10 +174,6 @@ export default function ActionPage() {
     }
   }, [activeDownstreamNode, data]);
 
-  if (!data) {
-    return <ContentLoader fullPage />;
-  }
-
   if (error) {
     return (
       <Container className="pt-5">
@@ -186,7 +182,11 @@ export default function ActionPage() {
     );
   }
 
-  if (!data || !data.action) {
+  if (!data) {
+    return <ContentLoader fullPage />;
+  }
+
+  if (!data.action) {
     return <ErrorMessage message={t('page-not-found')} />;
   }
 


### PR DESCRIPTION
## Description
The `!data` check on the action details page was before the `error` check, meaning the error was never displayed.

## Screenshots/Videos (if applicable)
https://app.asana.com/1/1201243246741462/project/1206806085204494/task/1214822147997640?focus=true
