### PR TITLE
Do not fetch all actions data for actions chooser

### DIFF
--- a/e2e-tests/__generated__/graphql.ts
+++ b/e2e-tests/__generated__/graphql.ts
@@ -12,10 +12,20 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
+  /** Date (isoformat) */
   Date: { input: any; output: any; }
+  /** Date with time (isoformat) */
   DateTime: { input: any; output: any; }
+  /** The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf). */
   JSON: { input: any; output: any; }
+  /**
+   * Allows use of a JSON String for input / output from the GraphQL schema.
+   *
+   * Use of this type is *not recommended* as you lose the benefits of having a defined, static
+   * schema (one of the key benefits of GraphQL).
+   */
   JSONString: { input: any; output: any; }
+  /** GraphQL type for an integer that must be equal or greater than zero. */
   PositiveInt: { input: any; output: any; }
   RichText: { input: any; output: any; }
   UUID: { input: any; output: any; }
@@ -43,6 +53,11 @@ export enum ChangeTargetKind {
   Unknown = 'UNKNOWN'
 }
 
+export enum DataPointCommentReviewState {
+  Resolved = 'RESOLVED',
+  Unresolved = 'UNRESOLVED'
+}
+
 /** Which governance level is applicable for an action */
 export enum DecisionLevel {
   Eu = 'EU',
@@ -54,6 +69,37 @@ export enum DimensionKind {
   Common = 'COMMON',
   Node = 'NODE',
   Scenario = 'SCENARIO'
+}
+
+/** An enumeration. */
+export enum FrameworksMeasureTemplateDefaultValueScalingChoices {
+  /** Population */
+  Population = 'POPULATION'
+}
+
+/** An enumeration. */
+export enum FrameworksMeasureTemplatePriorityChoices {
+  /** High */
+  High = 'HIGH',
+  /** Low */
+  Low = 'LOW',
+  /** Medium */
+  Medium = 'MEDIUM'
+}
+
+export enum InstanceMemberRole {
+  Admin = 'ADMIN',
+  Reviewer = 'REVIEWER',
+  SuperAdmin = 'SUPER_ADMIN',
+  Viewer = 'VIEWER'
+}
+
+/** An enumeration. */
+export enum ModelAction {
+  Add = 'ADD',
+  Change = 'CHANGE',
+  Delete = 'DELETE',
+  View = 'VIEW'
 }
 
 export enum NodeKind {

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -12,10 +12,20 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
+  /** Date (isoformat) */
   Date: { input: any; output: any; }
+  /** Date with time (isoformat) */
   DateTime: { input: string; output: string; }
+  /** The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf). */
   JSON: { input: any; output: any; }
+  /**
+   * Allows use of a JSON String for input / output from the GraphQL schema.
+   *
+   * Use of this type is *not recommended* as you lose the benefits of having a defined, static
+   * schema (one of the key benefits of GraphQL).
+   */
   JSONString: { input: string; output: string; }
+  /** GraphQL type for an integer that must be equal or greater than zero. */
   PositiveInt: { input: number; output: number; }
   RichText: { input: string; output: string; }
   UUID: { input: string; output: string; }
@@ -98,6 +108,11 @@ export type CreateNodeInput = {
   tags: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
+export enum DataPointCommentReviewState {
+  Resolved = 'RESOLVED',
+  Unresolved = 'UNRESOLVED'
+}
+
 /** Which governance level is applicable for an action */
 export enum DecisionLevel {
   Eu = 'EU',
@@ -146,6 +161,13 @@ export type InputPortInput = {
   supportedDimensions: InputMaybe<Array<Scalars['String']['input']>>;
   unit: InputMaybe<Scalars['String']['input']>;
 };
+
+export enum InstanceMemberRole {
+  Admin = 'ADMIN',
+  Reviewer = 'REVIEWER',
+  SuperAdmin = 'SUPER_ADMIN',
+  Viewer = 'VIEWER'
+}
 
 /** An enumeration. */
 export enum ModelAction {
@@ -215,7 +237,8 @@ export enum PrimaryLayoutClass {
 export type RegisterUserInput = {
   email: Scalars['String']['input'];
   firstName: InputMaybe<Scalars['String']['input']>;
-  frameworkId: Scalars['String']['input'];
+  frameworkId: InputMaybe<Scalars['ID']['input']>;
+  invitationToken: InputMaybe<Scalars['String']['input']>;
   lastName: InputMaybe<Scalars['String']['input']>;
   password: Scalars['String']['input'];
 };
@@ -2857,6 +2880,52 @@ export type ActionListQuery = (
       & { __typename: 'ActionImpact' }
     )> }
     & { __typename: 'ImpactOverviewType' }
+  )> }
+  & { __typename: 'Query' }
+);
+
+export type ActionsForChooserQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type ActionsForChooserQuery = (
+  { actions: Array<(
+    { id: string, name: string, parameters: Array<
+      | (
+        { id: string, label: string | null, description: string | null, nodeRelativeId: string | null, isCustomized: boolean, isCustomizable: boolean, boolValue: boolean | null, boolDefaultValue: boolean | null, node: (
+          { id: string }
+          & { __typename: 'ActionNode' | 'Node' }
+        ) | null }
+        & { __typename: 'BoolParameterType' }
+      )
+      | (
+        { minValue: number | null, maxValue: number | null, step: number | null, id: string, label: string | null, description: string | null, nodeRelativeId: string | null, isCustomized: boolean, isCustomizable: boolean, numberValue: number | null, numberDefaultValue: number | null, unit: (
+          { id: string, htmlShort: string }
+          & { __typename: 'UnitType' }
+        ) | null, node: (
+          { id: string }
+          & { __typename: 'ActionNode' | 'Node' }
+        ) | null }
+        & { __typename: 'NumberParameterType' }
+      )
+      | (
+        { id: string, label: string | null, description: string | null, nodeRelativeId: string | null, isCustomized: boolean, isCustomizable: boolean, stringValue: string | null, stringDefaultValue: string | null, node: (
+          { id: string }
+          & { __typename: 'ActionNode' | 'Node' }
+        ) | null }
+        & { __typename: 'StringParameterType' }
+      )
+      | (
+        { id: string, label: string | null, description: string | null, nodeRelativeId: string | null, isCustomized: boolean, isCustomizable: boolean, node: (
+          { id: string }
+          & { __typename: 'ActionNode' | 'Node' }
+        ) | null }
+        & { __typename: 'UnknownParameterType' }
+      )
+    >, group: (
+      { id: string, name: string, color: string | null }
+      & { __typename: 'ActionGroupType' }
+    ) | null }
+    & { __typename: 'ActionNode' }
   )> }
   & { __typename: 'Query' }
 );

--- a/src/common/__generated__/possible_types.json
+++ b/src/common/__generated__/possible_types.json
@@ -8,8 +8,21 @@
       "OperationInfo",
       "OutputPortType"
     ],
+    "AddUserToInstancePayload": [
+      "OperationInfo",
+      "User",
+      "UserNotFoundError"
+    ],
+    "CreateDataPointCommentPayload": [
+      "DataPointComment",
+      "OperationInfo"
+    ],
     "CreateDataPointPayload": [
       "DataPoint",
+      "OperationInfo"
+    ],
+    "CreateDataSourcePayload": [
+      "DataSource",
       "OperationInfo"
     ],
     "CreateDimensionCategoriesPayload": [
@@ -33,6 +46,14 @@
       "OperationInfo",
       "ScenarioType"
     ],
+    "CreateSourceReferencePayload": [
+      "DatasetSourceReference",
+      "OperationInfo"
+    ],
+    "DeleteDataSourcePayload": [
+      "ModelDeletePayload",
+      "OperationInfo"
+    ],
     "EdgeTransformationUnion": [
       "AssignCategoryTransformationType",
       "FlattenTransformationType",
@@ -47,6 +68,10 @@
     "InputPortBindingUnion": [
       "DatasetPortType",
       "NodeEdgeType"
+    ],
+    "InviteUserToInstancePayload": [
+      "InstanceInvitation",
+      "OperationInfo"
     ],
     "NodeConfigUnion": [
       "ActionConfigType",
@@ -79,6 +104,10 @@
     "RegisterUserPayload": [
       "OperationInfo",
       "RegisterUserResult"
+    ],
+    "ResolveDataPointCommentPayload": [
+      "DataPointComment",
+      "OperationInfo"
     ],
     "SetInstanceLockedPayload": [
       "OperationInfo",
@@ -126,8 +155,20 @@
       "TimeBlock",
       "URLBlock"
     ],
+    "UnresolveDataPointCommentPayload": [
+      "DataPointComment",
+      "OperationInfo"
+    ],
+    "UpdateDataPointCommentPayload": [
+      "DataPointComment",
+      "OperationInfo"
+    ],
     "UpdateDataPointPayload": [
       "DataPoint",
+      "OperationInfo"
+    ],
+    "UpdateDataSourcePayload": [
+      "DataSource",
       "OperationInfo"
     ],
     "UpdateDimensionCategoriesPayload": [

--- a/src/components/scenario/ActionsChooser.tsx
+++ b/src/components/scenario/ActionsChooser.tsx
@@ -10,17 +10,19 @@ import {
   lighten,
 } from '@mui/material';
 
-import { useQuery, useReactiveVar } from '@apollo/client/react';
+import { useQuery } from '@apollo/client/react';
 
 import { useTheme } from '@common/themes';
 import styled from '@common/themes/styled';
 
-import type { ActionListQuery, ActionListQueryVariables } from '@/common/__generated__/graphql';
-import { activeGoalVar } from '@/common/cache';
+import type {
+  ActionsForChooserQuery,
+  ActionsForChooserQueryVariables,
+} from '@/common/__generated__/graphql';
 import type { TFunction } from '@/common/i18n';
 import { useTranslation } from '@/common/i18n';
 import { findActionEnabledParam } from '@/common/preprocess';
-import { GET_ACTION_LIST } from '@/queries/getActionList';
+import { GET_ACTIONS_FOR_CHOOSER } from '@/queries/getActionsForChooser';
 import ActionParameters from '../general/ActionParameters';
 
 const ActionsList = styled.div`
@@ -114,18 +116,17 @@ function ActionListCard(props: ActionListCardProps) {
   );
 }
 
-type ActionsSummaryAction = ActionListQuery['actions'][0];
+type ActionsSummaryAction = ActionsForChooserQuery['actions'][0];
 
 export default function ActionsChooser() {
-  const activeGoal = useReactiveVar(activeGoalVar);
   const { t } = useTranslation();
-  const queryResp = useQuery<ActionListQuery, ActionListQueryVariables>(GET_ACTION_LIST, {
-    variables: {
-      goal: activeGoal?.id ?? null,
-    },
-    fetchPolicy: 'cache-and-network',
-    notifyOnNetworkStatusChange: true,
-  });
+  const queryResp = useQuery<ActionsForChooserQuery, ActionsForChooserQueryVariables>(
+    GET_ACTIONS_FOR_CHOOSER,
+    {
+      fetchPolicy: 'cache-and-network',
+      notifyOnNetworkStatusChange: true,
+    }
+  );
 
   const { error, loading, previousData } = queryResp;
   const data = queryResp.data ?? previousData;

--- a/src/queries/getActionsForChooser.ts
+++ b/src/queries/getActionsForChooser.ts
@@ -1,0 +1,22 @@
+import { gql } from '@apollo/client';
+
+import { ACTION_PARAMETER_FRAGMENT } from './actionParameterFragment';
+
+export const GET_ACTIONS_FOR_CHOOSER = gql`
+  query ActionsForChooser {
+    actions(onlyRoot: true) {
+      id
+      name
+      parameters {
+        ...ActionParameter
+      }
+      group {
+        id
+        name
+        color
+      }
+    }
+  }
+
+  ${ACTION_PARAMETER_FRAGMENT}
+`;


### PR DESCRIPTION
`GET_ACTION_LIST` is a heavy query and we were using it also for action chooser where only a minimal amount of data is needed per action.  Creates a slimmer `GET_ACTIONS_FOR_CHOOSER`. This should help with some performance problems reported for calculation heavy plans.