### PR TITLE
Fix overflowing impact bars when positive and negative impacts cancel each other out

### DIFF
--- a/src/components/general/ActionsList.tsx
+++ b/src/components/general/ActionsList.tsx
@@ -281,15 +281,17 @@ export default function ActionsList({
     }
   };
 
-  // Totals for percent bars — excluded or missing-value actions don't contribute
+  // Sum of absolute values per column for percent bars. Using the net sum previously
+  // caused bars to overflow when positive and negative values cancel each other out
   const totals = useMemo(() => {
     return columns.reduce(
       (acc, col) => {
-        acc[col.key] = filteredActions.reduce((sum, a) => {
+        acc[col.key] = filteredActions.reduce((sumAbs, a) => {
           const enabledParam = findActionEnabledParam(a.parameters);
           const isIncluded = !refetching && (enabledParam?.boolValue ?? false);
           const v = col.getValue(a);
-          return isIncluded && v !== null ? sum + v : sum;
+
+          return isIncluded && v !== null ? sumAbs + Math.abs(v) : sumAbs;
         }, 0);
         return acc;
       },


### PR DESCRIPTION
## Description
The percent bars were previously sized using the net sum of action impact values. When actions with both positive and negative impacts cancel each other out, the net sum approaches zero and bars overflow their cells massively.

Fixed by using the sum of absolute values instead. This preserves the stacked-like bar style (i.e. all bars together in a column fill the cell) while preventing the explosion overvlow

## Screenshots/Videos (if applicable)
### After / Before
<img width="2560" height="1440" alt="Screenshot 2026-05-22 at 11 02 50" src="https://github.com/user-attachments/assets/f65addce-db2f-4833-a325-cf8000b084a3" />
<img width="2560" height="1440" alt="Screenshot 2026-05-22 at 11 02 45" src="https://github.com/user-attachments/assets/6d91d362-e35a-493b-8c60-c85fc112181c" />
<img width="2560" height="1440" alt="Screenshot 2026-05-22 at 11 02 24" src="https://github.com/user-attachments/assets/0e0d8805-1d29-46bf-89b8-efe2483a56cc" />
<img width="2560" height="1440" alt="Screenshot 2026-05-22 at 11 02 56" src="https://github.com/user-attachments/assets/36a8db71-d7e7-4175-b456-fca9fc568bdc" />


