### PR TITLE
Fix broken titles

### DIFF
--- a/src/app/root/[domain]/[lang]/(with-layout)/actions/[slug]/page.tsx
+++ b/src/app/root/[domain]/[lang]/(with-layout)/actions/[slug]/page.tsx
@@ -241,9 +241,6 @@ export default function ActionPage() {
 
   return (
     <>
-      <title>
-        {site.title} | {action.name}
-      </title>
       <HeaderSection>
         <Container fixed maxWidth="xl">
           <PageHeader>

--- a/src/app/root/[domain]/[lang]/(with-layout)/node/[slug]/page.tsx
+++ b/src/app/root/[domain]/[lang]/(with-layout)/node/[slug]/page.tsx
@@ -155,9 +155,6 @@ export default function NodePage() {
 
   return (
     <>
-      <title>
-        {site.title} | {node.name}
-      </title>
       <HeaderSection $color={node.color || undefined}>
         <Container fixed maxWidth="xl">
           <PageHeader>

--- a/src/components/common/PathsError.tsx
+++ b/src/components/common/PathsError.tsx
@@ -97,7 +97,6 @@ export default function PathsError({ statusCode, title: titleProp, err }: PathsE
   if (!theme) {
     return (
       <>
-        <title>{title}</title>
         <main id="container">
           <div id="card">
             <h1>{title}</h1>

--- a/src/components/pages/Page.tsx
+++ b/src/components/pages/Page.tsx
@@ -126,11 +126,6 @@ function Page(props: PageProps) {
   }
   return (
     <>
-      {site ? (
-        <title>
-          {site.title} | {page.title}
-        </title>
-      ) : null}
       {headerExtra}
       <Suspense fallback={<PageLoader theme={theme} />}>{pageContent}</Suspense>
     </>


### PR DESCRIPTION
## Description
Remove the `<title>` hoisting from page components, which caused an empty title tag and the site URL to be displayed for all pages in the tab title. Stick with a consistent title across all pages for now as a quick fix. If per-page titles are important (mainly if we expect Paths node or action details to be shared where rich previews are shown), then we should refactor the pages to use Next's `generateMetadata`.

## Screenshots/Videos (if applicable)

### Before
<img width="418" height="98" alt="image" src="https://github.com/user-attachments/assets/2d2320b2-3f46-4325-8ad2-6df69ac0afb7" />

### After
<img width="376" height="97" alt="image" src="https://github.com/user-attachments/assets/8ad1144b-ea28-41e2-a443-06df8e915f94" />

## Related issue
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1215440815778092?focus=true

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [-] **Built E2E tests** (if applicable. E2E tests added/updated)
- [-] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [-] **New strings are translatable** (all user-facing text uses i18n)
- [-] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [-] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. paths backend)
