### PR TITLE
Rename scenario bar hiding feature

### DIFF
--- a/src/app/root/[domain]/[lang]/(with-layout)/actions/[slug]/page.tsx
+++ b/src/app/root/[domain]/[lang]/(with-layout)/actions/[slug]/page.tsx
@@ -141,9 +141,9 @@ export default function ActionPage() {
   const site = useSite();
   const [activeDownstreamNode, setActiveDownstreamNode] = useState<string | undefined>(undefined);
   const theme = useTheme();
-  const { hideNodeDetails } = useFeatures();
+  const { hideScenarioEditor } = useFeatures();
 
-  const isScenarioEditable = !hideNodeDetails;
+  const isScenarioEditable = !hideScenarioEditor;
 
   const queryResp = useQuery<ActionContentQuery, ActionContentQueryVariables>(GET_ACTION_CONTENT, {
     fetchPolicy: 'cache-and-network',

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -4420,7 +4420,7 @@ export type InstanceContextQueryVariables = Exact<{ [key: string]: never; }>;
 export type InstanceContextQuery = (
   { instance: (
     { id: string, name: string, themeIdentifier: string | null, owner: string | null, defaultLanguage: string, supportedLanguages: Array<string>, targetYear: number | null, modelEndYear: number, referenceYear: number | null, minimumHistoricalYear: number, maximumHistoricalYear: number | null, leadTitle: string, leadParagraph: string | null, features: (
-      { hideNodeDetails: boolean, maximumFractionDigits: number | null, baselineVisibleInGraphs: boolean, showAccumulatedEffects: boolean, showSignificantDigits: number | null, showRefreshPrompt: boolean }
+      { hideScenarioEditor: boolean, maximumFractionDigits: number | null, baselineVisibleInGraphs: boolean, showAccumulatedEffects: boolean, showSignificantDigits: number | null, showRefreshPrompt: boolean }
       & { __typename: 'InstanceFeaturesType' }
     ), introContent: Array<
       | (

--- a/src/components/general/ActionsList.tsx
+++ b/src/components/general/ActionsList.tsx
@@ -97,14 +97,14 @@ export default function ActionsList({
   const formatNumber = useNumberFormatter();
   const theme = useTheme();
   const [openRows, setOpenRows] = useState<Record<string, boolean>>({});
-  const { hideNodeDetails } = useFeatures();
+  const { hideScenarioEditor } = useFeatures();
 
   const cardBgPrimary = theme.cardBackground?.primary ?? theme.palette.background.paper;
   const cardBgSecondary = theme.cardBackground?.secondary ?? theme.palette.background.default;
   const textPrimary = theme.textColor?.primary ?? theme.palette.text.primary;
   const textSecondary = theme.textColor?.secondary ?? theme.palette.text.primary;
   const textTertiary = theme.textColor?.tertiary ?? theme.palette.text.secondary;
-  const isScenarioEditable = !hideNodeDetails;
+  const isScenarioEditable = !hideScenarioEditor;
 
   // hide ungrouped actions if at least one group exists
   const filteredActions = useMemo(() => {

--- a/src/components/general/OutcomeNodeContent.tsx
+++ b/src/components/general/OutcomeNodeContent.tsx
@@ -101,7 +101,7 @@ const OutcomeNodeContent = ({
   const outcomeChange = getMetricChange(nodesBase, nodesTotal);
   const unit = node.metric?.unit?.htmlLong || node.metric?.unit?.htmlShort;
 
-  const showNodeLinks = !instance.features?.hideNodeDetails;
+  const showNodeLinks = !instance.features?.hideScenarioEditor;
   const maximumFractionDigits = instance.features?.maximumFractionDigits ?? undefined;
 
   // TODO: Remove showRefreshPrompt check when node help text is moved to the backend

--- a/src/components/pages/OutcomePage.tsx
+++ b/src/components/pages/OutcomePage.tsx
@@ -56,7 +56,7 @@ export default function OutcomePage(props: OutcomePageProps) {
 
   const activeScenario = useReactiveVar(activeScenarioVar);
 
-  const showSettingsPanel = !instance.features?.hideNodeDetails;
+  const showSettingsPanel = !instance.features?.hideScenarioEditor;
   const pageLeadTitle = page.leadTitle || instance.leadTitle;
   const pageLeadParagraph = page.leadParagraph || instance.leadParagraph;
 

--- a/src/components/scenario/ScenarioPanel.tsx
+++ b/src/components/scenario/ScenarioPanel.tsx
@@ -124,7 +124,7 @@ const RELATIVE_STYLES = {
 const DRAWER_WIDTH = 320;
 
 const ScenarioPanel = () => {
-  const { hideNodeDetails } = useFeatures();
+  const { hideScenarioEditor } = useFeatures();
   const theme = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
   const { isPanelFixed, isPanelMini, initialHeight } = useIsPanelStuck(containerRef);
@@ -150,7 +150,7 @@ const ScenarioPanel = () => {
   const { error, data } = useQuery<InstanceGoalOutcomeQuery, InstanceGoalOutcomeQueryVariables>(
     GET_INSTANCE_GOAL_OUTCOME,
     {
-      skip: !!hideNodeDetails,
+      skip: !!hideScenarioEditor,
       variables: {
         goal: activeGoal?.id ?? '',
       },
@@ -159,7 +159,7 @@ const ScenarioPanel = () => {
 
   // if (loading) return <Skeleton variant="text" width={100} height={24} />;
   if (error) return <div>error!</div>;
-  if (hideNodeDetails) return null;
+  if (hideScenarioEditor) return null;
 
   const minYear = site.minYear;
   const maxYear = site.maxYear;

--- a/src/queries/instance.ts
+++ b/src/queries/instance.ts
@@ -30,7 +30,7 @@ const GET_INSTANCE_CONTEXT = gql`
       leadTitle
       leadParagraph
       features {
-        hideNodeDetails
+        hideScenarioEditor
         maximumFractionDigits
         baselineVisibleInGraphs
         showAccumulatedEffects


### PR DESCRIPTION
> ⚠️  Pending backend change deployment (hence the failing CI)

## Description
The purpose of `hide_node_details` (used by NZP) has changed over time, this just updates the naming to reflect that meaning. 

## Requirements, dependencies and related PRs
https://github.com/kausaltech/kausal-paths/pull/265

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built E2E tests** (if applicable. E2E tests added/updated)
- [-] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [-] **New strings are translatable** (all user-facing text uses i18n)
- [-] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. paths backend)
