### PR TITLE
Handle framework relative models

### DIFF
--- a/eslint-baseline.json
+++ b/eslint-baseline.json
@@ -54,17 +54,6 @@
       "count": 1
     }
   },
-  "src/components/Layout.tsx": {
-    "@typescript-eslint/consistent-type-imports": {
-      "count": 1
-    },
-    "@typescript-eslint/prefer-nullish-coalescing": {
-      "count": 1
-    },
-    "react-hooks/static-components": {
-      "count": 2
-    }
-  },
   "src/components/common/ErrorMessage.tsx": {
     "react/prop-types": {
       "count": 1

--- a/src/app/root/[domain]/[lang]/auth/create-instance/page.tsx
+++ b/src/app/root/[domain]/[lang]/auth/create-instance/page.tsx
@@ -62,7 +62,23 @@ function slugify(text: string): string {
     .trim()
     .replace(/[^\w\s-]/g, '')
     .replace(/[\s_]+/g, '-')
-    .replace(/-+/g, '-');
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// Generate a short, URL-safe random suffix to ensure identifier uniqueness.
+function randomSuffix(length = 6): string {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => alphabet[b % alphabet.length]).join('');
+}
+
+// Build a unique identifier from the framework and the user-provided name,
+// hidden from the user: {framework}-{slugified-name}-{hash}
+function generateIdentifier(frameworkId: string, name: string): string {
+  const parts = [slugify(frameworkId), slugify(name), randomSuffix()].filter(Boolean);
+  return parts.join('-');
 }
 
 export default function CreateInstancePage() {
@@ -74,8 +90,6 @@ export default function CreateInstancePage() {
   const isLogoBitmap = theme.themeLogoUrl?.endsWith('.png');
 
   const [name, setName] = useState('');
-  const [identifier, setIdentifier] = useState('');
-  const [identifierTouched, setIdentifierTouched] = useState(false);
   const [organizationName, setOrganizationName] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [created, setCreated] = useState<{ instanceId: string; instanceName: string } | null>(null);
@@ -87,13 +101,6 @@ export default function CreateInstancePage() {
     skip: !frameworkId,
   });
   const frameworkName = frameworkData?.framework?.name;
-
-  const handleNameChange = (value: string) => {
-    setName(value);
-    if (!identifierTouched) {
-      setIdentifier(slugify(value));
-    }
-  };
 
   const handleSubmit = async (e: { preventDefault: () => void }) => {
     e.preventDefault();
@@ -110,7 +117,7 @@ export default function CreateInstancePage() {
           input: {
             frameworkId,
             name,
-            identifier,
+            identifier: generateIdentifier(frameworkId, name),
             organizationName,
           },
         },
@@ -190,22 +197,11 @@ export default function CreateInstancePage() {
                 <TextField
                   label="Instance name"
                   value={name}
-                  onChange={(e) => handleNameChange(e.target.value)}
+                  onChange={(e) => setName(e.target.value)}
                   required
                   fullWidth
                   autoFocus
                   helperText="A descriptive name for your instance, e.g. your city name"
-                />
-                <TextField
-                  label="Identifier"
-                  value={identifier}
-                  onChange={(e) => {
-                    setIdentifier(e.target.value);
-                    setIdentifierTouched(true);
-                  }}
-                  required
-                  fullWidth
-                  helperText="A unique URL-safe identifier (auto-generated from the name)"
                 />
                 <TextField
                   label="Organization name"

--- a/src/app/root/[domain]/[lang]/layout.tsx
+++ b/src/app/root/[domain]/[lang]/layout.tsx
@@ -74,13 +74,17 @@ function buildSiteContext(
   const instance = data.instance;
   const assetPrefix = getAssetPrefix();
 
+  const siteTitle = instance?.frameworkConfig?.framework?.name
+    ? `${instance.frameworkConfig.framework.name}: ${instance.name}`
+    : instance.name;
+
   const siteContext = {
     scenarios,
     parameters,
     menuPages,
     footerPages,
     additionalLinkPages,
-    title: instance.name,
+    title: siteTitle,
     owner: instance.owner!,
     apolloConfig: {
       instanceHostname: ctx.instanceHostname,

--- a/src/app/root/[domain]/[lang]/layout.tsx
+++ b/src/app/root/[domain]/[lang]/layout.tsx
@@ -139,15 +139,18 @@ export async function generateMetadata(props: LayoutProps): Promise<Metadata> {
   const data = resp!;
   const theme = await loadTheme(data.instance.themeIdentifier || 'default');
 
+  const siteName = data.instance?.frameworkConfig?.framework?.name
+    ? `${data.instance.frameworkConfig.framework.name}: ${data.instance.name}`
+    : data.instance.name;
   return {
     robots: 'noindex, nofollow',
-    title: data.instance.name,
+    title: siteName,
     description: data.instance.leadParagraph,
     openGraph: {
       title: data.instance.name,
       description: data.instance.leadParagraph ?? undefined,
       type: 'website',
-      siteName: data.instance.name,
+      siteName: siteName,
       images: [`${getAssetPrefix()}/static/themes/default/images/og-image-default.png`],
     },
     metadataBase: new URL(origin),

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -4358,7 +4358,13 @@ export type InstanceContextQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type InstanceContextQuery = (
   { instance: (
-    { id: string, name: string, themeIdentifier: string | null, owner: string | null, defaultLanguage: string, supportedLanguages: Array<string>, targetYear: number | null, modelEndYear: number, referenceYear: number | null, minimumHistoricalYear: number, maximumHistoricalYear: number | null, leadTitle: string, leadParagraph: string | null, features: (
+    { id: string, name: string, themeIdentifier: string | null, owner: string | null, defaultLanguage: string, supportedLanguages: Array<string>, targetYear: number | null, modelEndYear: number, referenceYear: number | null, minimumHistoricalYear: number, maximumHistoricalYear: number | null, leadTitle: string, leadParagraph: string | null, frameworkConfig: (
+      { id: string, framework: (
+        { id: string, identifier: string, name: string }
+        & { __typename: 'Framework' }
+      ) }
+      & { __typename: 'FrameworkConfig' }
+    ) | null, features: (
       { hideNodeDetails: boolean, maximumFractionDigits: number | null, baselineVisibleInGraphs: boolean, showAccumulatedEffects: boolean, showSignificantDigits: number | null, showRefreshPrompt: boolean }
       & { __typename: 'InstanceFeaturesType' }
     ), introContent: Array<

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import React from 'react';
 import { usePathname } from 'next/navigation';
 
 import { Box, Drawer, styled, useTheme } from '@mui/material';
@@ -11,12 +10,11 @@ import { useReactiveVar } from '@apollo/client/react';
 import { scenarioEditorDrawerOpenVar } from '@/common/cache';
 import { useTranslation } from '@/common/i18n';
 import { useInstance } from '@/common/instance';
-import Footer from '@/components/common/Footer';
-import GlobalNav from '@/components/common/GlobalNav';
+import { formatUrl } from '@/common/links';
 import ScenarioEditor from '@/components/scenario/ScenarioEditor';
 import { useSiteOrNull } from '@/context/site';
 import IntroModal from './common/IntroModal';
-import { useCustomComponent } from './custom';
+import { FooterSlot, GlobalNavSlot } from './custom';
 import { RefreshPrompt } from './general/RefreshPrompt';
 
 const DRAWER_WIDTH = 320;
@@ -79,7 +77,7 @@ const Layout = ({ children }: React.PropsWithChildren) => {
   const site = useSiteOrNull();
   const { t } = useTranslation();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-  const { menuPages, iconBase: fallbackIconBase, ogImage, additionalLinkPages } = site || {};
+  const { menuPages, additionalLinkPages } = site ?? {};
   const drawerOpen = useReactiveVar(scenarioEditorDrawerOpenVar);
 
   const handleDrawerClose = () => {
@@ -87,8 +85,6 @@ const Layout = ({ children }: React.PropsWithChildren) => {
   };
 
   let activePage: MenuPage | undefined;
-
-  const iconBase = theme.name ? `/static/themes/${theme.name}/images/favicon` : fallbackIconBase;
 
   const rawMenu = Array.isArray(menuPages) ? menuPages : [];
   const menuItems: MenuPage[] = rawMenu.filter(isMenuPage).map((page) => ({
@@ -104,15 +100,23 @@ const Layout = ({ children }: React.PropsWithChildren) => {
     urlPath: page.urlPath,
   }));
 
-  menuItems.forEach((page) => {
-    if (pathname === page.urlPath) {
+  // `urlPath` is the raw backend path (e.g. `/some-page`), while `pathname`
+  // includes the instance basePath and locale prefix. Resolve each menu page to
+  // its full path before comparing.
+  const resolvedMenuItems = menuItems.map((page) => ({
+    page,
+    fullPath: formatUrl(site, page.urlPath),
+  }));
+
+  resolvedMenuItems.forEach(({ page, fullPath }) => {
+    if (pathname === fullPath) {
       activePage = page;
     }
   });
 
   if (!activePage) {
-    menuItems.forEach((page) => {
-      if (pathname.startsWith(page.urlPath)) {
+    resolvedMenuItems.forEach(({ page, fullPath }) => {
+      if (pathname.startsWith(fullPath)) {
         activePage = page;
       }
     });
@@ -125,9 +129,6 @@ const Layout = ({ children }: React.PropsWithChildren) => {
     urlPath: page.urlPath,
     active: page === activePage,
   }));
-
-  const NavComponent = useCustomComponent('GlobalNav', GlobalNav);
-  const FooterComponent = useCustomComponent('Footer', Footer);
 
   const instance = useInstance();
 
@@ -215,7 +216,7 @@ const Layout = ({ children }: React.PropsWithChildren) => {
             minHeight: '100vh',
           }}
         >
-          <NavComponent
+          <GlobalNavSlot
             siteTitle={site?.title || ''}
             ownerName={site?.owner || undefined}
             navItems={navItems}
@@ -227,14 +228,12 @@ const Layout = ({ children }: React.PropsWithChildren) => {
             </Box>
             {children}
           </Box>
-          <FooterComponent additionalLinks={additionalLinkItems} />
+          <FooterSlot additionalLinks={additionalLinkItems} />
         </Box>
       </Box>
       {introModalEnabled && <IntroModal title={title} paragraph={paragraph} />}
     </>
   );
 };
-
-export const getLayout = (page) => <Layout>{page}</Layout>;
 
 export default Layout;

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -434,7 +434,7 @@ function SiteFooter(props: SiteFooterProps) {
             {utilityLinks &&
               utilityLinks.map((page) => (
                 <UtilityItem key={page.id}>
-                  <a href={page.slug}>
+                  <Link href={page.slug}>
                     {page.icon && (
                       <Icon
                         name={page.icon}
@@ -444,7 +444,7 @@ function SiteFooter(props: SiteFooterProps) {
                       />
                     )}
                     {page.name}
-                  </a>
+                  </Link>
                 </UtilityItem>
               ))}
             <UtilityItem>

--- a/src/components/common/GlobalNav.tsx
+++ b/src/components/common/GlobalNav.tsx
@@ -101,7 +101,7 @@ const SiteTitle = styled.div`
     font-size: ${(props) => props.theme.fontSizeMd};
   }
 `;
-const HomeLink = styled.a<{ $hideLogoOnMobile?: boolean }>`
+const HomeLink = styled(Link)<{ $hideLogoOnMobile?: boolean }>`
   display: flex;
   align-items: center;
   color: ${(props) => props.theme.brandNavColor};

--- a/src/components/common/PublicUserNav.tsx
+++ b/src/components/common/PublicUserNav.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import Link from 'next/link';
 
 import {
   Avatar,
@@ -19,6 +18,7 @@ import { gql } from '@apollo/client';
 import { useQuery } from '@apollo/client/react';
 import { BoxArrowRight, ChevronDown, PencilSquare } from 'react-bootstrap-icons';
 
+import { Link } from '@/common/links';
 import { authClient, useSession } from '@/lib/auth-client';
 
 const CAN_EDIT_MODEL = gql`

--- a/src/components/custom/README.md
+++ b/src/components/custom/README.md
@@ -9,4 +9,10 @@ and loaded dynamically.
 
 1. Add a component to be loaded dynamically in `src/components/custom/[theme-name]` e.g. `src/components/custom/sunnydale/GlobalNav`
 2. Add the component to the `CUSTOM_COMPONENTS` map
-3. Use the `useCustomComponents` hook wherever this custom component may be rendered
+3. Add (or reuse) a "slot" component (e.g. `GlobalNavSlot`) that resolves the
+   custom-or-fallback implementation for the active theme and renders it, then
+   use that slot wherever the component may be rendered.
+
+The slot must select the component and render it in the same scope (rather than
+returning it from a hook) so the React Compiler can verify the rendered
+component is static; see the comment in `index.tsx`.

--- a/src/components/custom/index.tsx
+++ b/src/components/custom/index.tsx
@@ -2,8 +2,8 @@ import type { ComponentType } from 'react';
 
 import { useTheme } from '@common/themes';
 
-import type { SiteFooterProps } from '@/components/common/Footer';
-import type { GlobalNavProps } from '@/components/common/GlobalNav';
+import Footer, { type SiteFooterProps } from '@/components/common/Footer';
+import GlobalNav, { type GlobalNavProps } from '@/components/common/GlobalNav';
 import FooterZurich from '@/components/custom/zurich/Footer';
 import GlobalNavZurich from '@/components/custom/zurich/GlobalNav';
 
@@ -19,11 +19,24 @@ export const CUSTOM_COMPONENTS: Record<string, CustomThemeComponents> = {
   },
 };
 
-export function useCustomComponent<CompName extends keyof CustomThemeComponents>(
-  componentName: CompName,
-  FallbackComponent: CustomThemeComponents[CompName]
-): CustomThemeComponents[CompName] {
+/**
+ * Slot components that resolve the right (custom or fallback) implementation for
+ * the active theme and render it.
+ *
+ * The selection happens in the same scope as the render, referencing the
+ * module-level components directly, so the React Compiler can verify the
+ * rendered component is static. Returning the component from a hook instead
+ * would cross a function boundary the compiler treats as opaque, tripping the
+ * "Cannot create components during render" rule.
+ */
+export function GlobalNavSlot(props: GlobalNavProps) {
   const theme = useTheme();
+  const Component = CUSTOM_COMPONENTS[theme.name]?.GlobalNav ?? GlobalNav;
+  return <Component {...props} />;
+}
 
-  return CUSTOM_COMPONENTS[theme.name]?.[componentName] ?? FallbackComponent;
+export function FooterSlot(props: SiteFooterProps) {
+  const theme = useTheme();
+  const Component = CUSTOM_COMPONENTS[theme.name]?.Footer ?? Footer;
+  return <Component {...props} />;
 }

--- a/src/components/graphs/ActionComparisonGraph.tsx
+++ b/src/components/graphs/ActionComparisonGraph.tsx
@@ -8,6 +8,7 @@ import { useTranslations } from 'next-intl';
 import { useTheme } from '@common/themes';
 import styled from '@common/themes/styled';
 
+import { Link } from '@/common/links';
 import { useNumberFormatter } from '@/common/numbers';
 import Icon from '@/components/common/icon';
 
@@ -167,14 +168,14 @@ function ActionComparisonGraph(props: ActionComparisonGraphProps) {
       {plot}
       {hoverId !== null && (
         <ActionDescription color={data.colors[hoverId] ?? undefined}>
-          <a href={`/actions/${actionIds[hoverId]}/`}>
+          <Link href={`/actions/${actionIds[hoverId]}/`}>
             <HoverGroupTag color={data.colors[hoverId] ?? undefined}>
               {actionGroups.find((group) => group.id === data.groups[hoverId])?.name}
             </HoverGroupTag>
             <h4>
               {data.actions[hoverId]} <Icon name="arrowRight" />
             </h4>
-          </a>
+          </Link>
           <Grid container spacing={2}>
             <Grid size={{ md: 3 }} sx={{ display: 'flex', alignItems: 'end' }}>
               <HoverValue>

--- a/src/components/graphs/MacGraph.tsx
+++ b/src/components/graphs/MacGraph.tsx
@@ -10,6 +10,7 @@ import { useTheme } from '@common/themes';
 import styled from '@common/themes/styled';
 
 import type { ActionListQuery } from '@/common/__generated__/graphql';
+import { Link } from '@/common/links';
 import { useNumberFormatter } from '@/common/numbers';
 import Icon from '@/components/common/icon';
 
@@ -294,14 +295,14 @@ function MacGraph(props: MacGraphProps) {
       {plot}
       {hoverId !== null && (
         <ActionDescription>
-          <a href={`/actions/${actionIds[hoverId]}/`}>
+          <Link href={`/actions/${actionIds[hoverId]}/`}>
             <HoverGroupTag color={data.colors[hoverId]}>
               {actionGroups.find((group) => group.id === data.groups[hoverId])?.name}
             </HoverGroupTag>
             <h4>
               {data.actions[hoverId]} <Icon name="arrowRight" />
             </h4>
-          </a>
+          </Link>
           <Grid container spacing={2}>
             <Grid size={{ md: 3 }} sx={{ display: 'flex', alignItems: 'end' }}>
               <HoverValue>

--- a/src/components/model-editor/ModelEditorNav.tsx
+++ b/src/components/model-editor/ModelEditorNav.tsx
@@ -47,6 +47,7 @@ import {
 
 import { nodeFiltersOpenVar, nodeFiltersVar } from '@/common/cache';
 import { useInstance } from '@/common/instance';
+import { Link as AppLink } from '@/common/links';
 import { getModelEditorBase } from './paths';
 
 const GET_NODE_SEARCH_LIST = gql`
@@ -430,10 +431,11 @@ export default function ModelEditorNav() {
         ))}
         <Divider />
         <MenuItem
-          onClick={() => {
-            setAnchorEl(null);
-            window.open('/', '_blank', 'noopener,noreferrer');
-          }}
+          component={AppLink}
+          href="/"
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => setAnchorEl(null)}
         >
           <ListItemIcon>
             <Compass size={16} />

--- a/src/queries/instance.ts
+++ b/src/queries/instance.ts
@@ -19,6 +19,14 @@ const GET_INSTANCE_CONTEXT = gql`
       id
       name
       themeIdentifier
+      frameworkConfig {
+        id
+        framework {
+          id
+          identifier
+          name
+        }
+      }
       owner
       defaultLanguage
       supportedLanguages

--- a/tsc-baseline.json
+++ b/tsc-baseline.json
@@ -52,36 +52,6 @@
       "count": 1,
       "message": "Parameter 'y' implicitly has an 'any' type."
     },
-    "db2cd6a352cd83e3e5967b5fdd19086a76b4320b": {
-      "file": "kausal_common/src/components/paths/NodeGraph.tsx",
-      "code": "TS2345",
-      "count": 1,
-      "message": "Argument of type '\"plot-total\"' is not assignable to parameter of type 'NamespacedMessageKeys<{ common: { \"abbr-per-annum\": string; \"action-impact\": string; action: string; \"action-name\": string; actions: string; \"actions-available\": string; \"actions-influencing-this\": string; \"affected-by\": string; ... 166 more ...; \"loading-calculation\": string; }; errors: { ...; }; 'model-editor': { ...'."
-    },
-    "b853863712579ed251f9333a66646af6c887b07a": {
-      "file": "kausal_common/src/components/paths/NodeGraph.tsx",
-      "code": "TS2345",
-      "count": 1,
-      "message": "Argument of type '\"target\"' is not assignable to parameter of type 'NamespacedMessageKeys<{ common: { \"abbr-per-annum\": string; \"action-impact\": string; action: string; \"action-name\": string; actions: string; \"actions-available\": string; \"actions-influencing-this\": string; \"affected-by\": string; ... 166 more ...; \"loading-calculation\": string; }; errors: { ...; }; 'model-editor': { ...'."
-    },
-    "94d0ba4339f7ead7200d087cffc268f958ee01a0": {
-      "file": "kausal_common/src/components/paths/NodeGraph.tsx",
-      "code": "TS2345",
-      "count": 1,
-      "message": "Argument of type '\"plot-baseline\"' is not assignable to parameter of type 'NamespacedMessageKeys<{ common: { \"abbr-per-annum\": string; \"action-impact\": string; action: string; \"action-name\": string; actions: string; \"actions-available\": string; \"actions-influencing-this\": string; \"affected-by\": string; ... 166 more ...; \"loading-calculation\": string; }; errors: { ...; }; 'model-editor': { ...'."
-    },
-    "f4e94bcc1033c96a11b051053ad89cb9b5bde744": {
-      "file": "kausal_common/src/components/paths/NodeGraph.tsx",
-      "code": "TS2345",
-      "count": 1,
-      "message": "Argument of type '\"calculated-emissions\"' is not assignable to parameter of type 'NamespacedMessageKeys<{ common: { \"abbr-per-annum\": string; \"action-impact\": string; action: string; \"action-name\": string; actions: string; \"actions-available\": string; \"actions-influencing-this\": string; \"affected-by\": string; ... 166 more ...; \"loading-calculation\": string; }; errors: { ...; }; 'model-editor': { ...'."
-    },
-    "492070e97bed2cc9e1aa9e0c91b068e87a538e0f": {
-      "file": "kausal_common/src/components/paths/NodeGraph.tsx",
-      "code": "TS2345",
-      "count": 1,
-      "message": "Argument of type '\"table-scenario-forecast\"' is not assignable to parameter of type 'NamespacedMessageKeys<{ common: { \"abbr-per-annum\": string; \"action-impact\": string; action: string; \"action-name\": string; actions: string; \"actions-available\": string; \"actions-influencing-this\": string; \"affected-by\": string; ... 166 more ...; \"loading-calculation\": string; }; errors: { ...; }; 'model-editor': { ...'."
-    },
     "838182a273f9a9159ac1f2ddaf4c9ec8e0418271": {
       "file": "kausal_common/src/components/paths/NodeGraph.tsx",
       "code": "TS7053",
@@ -111,12 +81,6 @@
       "code": "TS7053",
       "count": 1,
       "message": "Element implicitly has an 'any' type because expression of type 'Level' can't be used to index type 'Console'."
-    },
-    "007e1f074951bf350d3d84817970a5233422ce71": {
-      "file": "kausal_common/src/utils/paths/metric/slicing.ts",
-      "code": "TS2322",
-      "count": 1,
-      "message": "Type '{ id: string; type: string; options: string[]; }[]' is not assignable to type 'readonly { readonly id: string; readonly type: \"group\" | \"category\"; readonly options: readonly string[]; }[]'."
     },
     "d8d6c9f9a88f2c6de9c21b403e20195aa8ee4f20": {
       "file": "src/app/api/sentry-event/route.ts",
@@ -160,11 +124,11 @@
       "count": 1,
       "message": "Binding element 'message' implicitly has an 'any' type."
     },
-    "943208ae9e7ed319aaad8463479435857b6aae16": {
+    "48023cc95289f7b1028497f2c331eeef8035c2ef": {
       "file": "src/components/common/RichText.tsx",
       "code": "TS2339",
       "count": 1,
-      "message": "Property 'serveFileBaseUrl' does not exist on type '{ id: string; name: string; themeIdentifier: string | null; owner: string | null; defaultLanguage: string; supportedLanguages: string[]; targetYear: number | null; modelEndYear: number; ... 8 more ...; actionListPage: ({ ...; } & { ...; }) | null; } & { ...; }'."
+      "message": "Property 'serveFileBaseUrl' does not exist on type '{ id: string; name: string; themeIdentifier: string | null; owner: string | null; defaultLanguage: string; supportedLanguages: string[]; targetYear: number | null; modelEndYear: number; ... 9 more ...; actionListPage: ({ ...; } & { ...; }) | null; } & { ...; }'."
     },
     "df5056b7b533076a528a6de9f2ff2a44828c205c": {
       "file": "src/components/common/RichText.tsx",
@@ -207,12 +171,6 @@
       "code": "TS2339",
       "count": 6,
       "message": "Property 'stzh-link' does not exist on type 'JSX.IntrinsicElements'."
-    },
-    "1da2a05f8c1e7ce499fb3080f32a0e0b25e0ada9": {
-      "file": "src/components/CytoGraph.tsx",
-      "code": "TS7016",
-      "count": 1,
-      "message": "Could not find a declaration file for module 'cytoscape-elk'. '/Users/tero/Projects/Kausal/kausal-paths-ui/node_modules/.pnpm/cytoscape-elk@2.3.0_cytoscape@3.33.1/node_modules/cytoscape-elk/dist/cytoscape-elk.js' implicitly has an 'any' type."
     },
     "063cd75478478c61df6099bb2a2c5695ae70f105": {
       "file": "src/components/CytoGraph.tsx",
@@ -261,12 +219,6 @@
       "code": "TS2345",
       "count": 1,
       "message": "Argument of type 'string | undefined' is not assignable to parameter of type 'string'."
-    },
-    "91d27fdb7a43af3fb9acc5240cb63a1dc3265f6b": {
-      "file": "src/components/CytoGraph.tsx",
-      "code": "TS7016",
-      "count": 1,
-      "message": "Could not find a declaration file for module 'cytoscape-pdf-export'. '/Users/tero/Projects/Kausal/kausal-paths-ui/node_modules/.pnpm/cytoscape-pdf-export@0.0.3/node_modules/cytoscape-pdf-export/dist/cytoscape-pdf-export-cjs.js' implicitly has an 'any' type."
     },
     "a9fd285bb859cd73a25e2ac99d548623b0249513": {
       "file": "src/components/CytoGraph.tsx",
@@ -388,36 +340,6 @@
       "count": 1,
       "message": "Type '(event: SelectChangeEvent) => void' is not assignable to type '(event: ChangeEvent<HTMLInputElement, Element> | (Event & { target: { value: unknown; name: string; }; }), child: ReactNode) => void'."
     },
-    "12fe35fb051ce1601c085c795b71abc750927318": {
-      "file": "src/components/general/LanguageSelector.tsx",
-      "code": "TS7053",
-      "count": 1,
-      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ fi: string; en: string; de: string; sv: string; cs: string; da: string; lv: string; pl: string; es: string; el: string; }'."
-    },
-    "2990a5357c9c5f49050110d1097f22bfc386b171": {
-      "file": "src/components/general/NodeGraph.tsx",
-      "code": "TS7053",
-      "count": 1,
-      "message": "Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'TooltipBoxLayoutOption'."
-    },
-    "106d363340ecedf1c4f8e8764d57ef9025f70f58": {
-      "file": "src/components/general/NodeGraph.tsx",
-      "code": "TS7053",
-      "count": 1,
-      "message": "Element implicitly has an 'any' type because expression of type 'number' can't be used to index type '{}'."
-    },
-    "664267f3c4492d2b795712d8d1c58c8a5365e171": {
-      "file": "src/components/general/NodeGraph.tsx",
-      "code": "TS7053",
-      "count": 1,
-      "message": "Element implicitly has an 'any' type because expression of type 'number' can't be used to index type 'string | number | Date | Dictionary<OptionDataValue> | OptionDataValue[] | OptionDataItemObject<OptionDataValue>'."
-    },
-    "11add574afebe917fdbbbcbbbe62885a836b5bea": {
-      "file": "src/components/general/NodePlot.tsx",
-      "code": "TS7016",
-      "count": 1,
-      "message": "Could not find a declaration file for module 'react-json-to-csv'. '/Users/tero/Projects/Kausal/kausal-paths-ui/node_modules/.pnpm/react-json-to-csv@1.2.0/node_modules/react-json-to-csv/dist/index.js' implicitly has an 'any' type."
-    },
     "e9defc3dc196aa17226558a6ad265b9da1f5ee28": {
       "file": "src/components/general/OutcomeNodeContent.tsx",
       "code": "TS2322",
@@ -453,78 +375,6 @@
       "code": "TS7053",
       "count": 1,
       "message": "Element implicitly has an 'any' type because expression of type 'number' can't be used to index type 'string | number | Date | Dictionary<OptionDataValue> | OptionDataValue[] | OptionDataItemObject<OptionDataValue>'."
-    },
-    "ae82c1181051d280e5b70b0d74fc545fcc8122b1": {
-      "file": "src/components/graphs/Plot.tsx",
-      "code": "TS7016",
-      "count": 1,
-      "message": "Could not find a declaration file for module 'plotly.js-locales/cs'. '/Users/tero/Projects/Kausal/kausal-paths-ui/node_modules/.pnpm/plotly.js-locales@3.5.0/node_modules/plotly.js-locales/cs.js' implicitly has an 'any' type."
-    },
-    "0bfbf0319215a5414184473827bcb4ef5c2aba72": {
-      "file": "src/components/graphs/Plot.tsx",
-      "code": "TS7016",
-      "count": 1,
-      "message": "Could not find a declaration file for module 'plotly.js-locales/da'. '/Users/tero/Projects/Kausal/kausal-paths-ui/node_modules/.pnpm/plotly.js-locales@3.5.0/node_modules/plotly.js-locales/da.js' implicitly has an 'any' type."
-    },
-    "4178142fb395e9fd69538c5f3f51d4c7dab458b3": {
-      "file": "src/components/graphs/Plot.tsx",
-      "code": "TS7016",
-      "count": 1,
-      "message": "Could not find a declaration file for module 'plotly.js-locales/de'. '/Users/tero/Projects/Kausal/kausal-paths-ui/node_modules/.pnpm/plotly.js-locales@3.5.0/node_modules/plotly.js-locales/de.js' implicitly has an 'any' type."
-    },
-    "7b707c6634aeb6b669dd367bf888d168819d9feb": {
-      "file": "src/components/graphs/Plot.tsx",
-      "code": "TS7016",
-      "count": 1,
-      "message": "Could not find a declaration file for module 'plotly.js-locales/de-ch'. '/Users/tero/Projects/Kausal/kausal-paths-ui/node_modules/.pnpm/plotly.js-locales@3.5.0/node_modules/plotly.js-locales/de-ch.js' implicitly has an 'any' type."
-    },
-    "da4909d75aca84d89d7a3fdc3b4becb864d1a4f5": {
-      "file": "src/components/graphs/Plot.tsx",
-      "code": "TS7016",
-      "count": 1,
-      "message": "Could not find a declaration file for module 'plotly.js-locales/el'. '/Users/tero/Projects/Kausal/kausal-paths-ui/node_modules/.pnpm/plotly.js-locales@3.5.0/node_modules/plotly.js-locales/el.js' implicitly has an 'any' type."
-    },
-    "1b844c7a998751cfd4d41a67db75f47dc48e1f00": {
-      "file": "src/components/graphs/Plot.tsx",
-      "code": "TS7016",
-      "count": 1,
-      "message": "Could not find a declaration file for module 'plotly.js-locales/es'. '/Users/tero/Projects/Kausal/kausal-paths-ui/node_modules/.pnpm/plotly.js-locales@3.5.0/node_modules/plotly.js-locales/es.js' implicitly has an 'any' type."
-    },
-    "8a6f8bbd81425ced3d762928cb80146c871fa400": {
-      "file": "src/components/graphs/Plot.tsx",
-      "code": "TS7016",
-      "count": 1,
-      "message": "Could not find a declaration file for module 'plotly.js-locales/fi'. '/Users/tero/Projects/Kausal/kausal-paths-ui/node_modules/.pnpm/plotly.js-locales@3.5.0/node_modules/plotly.js-locales/fi.js' implicitly has an 'any' type."
-    },
-    "4c0ac5e4dd2a6e7121a636d35d6becaee7770ac9": {
-      "file": "src/components/graphs/Plot.tsx",
-      "code": "TS7016",
-      "count": 1,
-      "message": "Could not find a declaration file for module 'plotly.js-locales/lv'. '/Users/tero/Projects/Kausal/kausal-paths-ui/node_modules/.pnpm/plotly.js-locales@3.5.0/node_modules/plotly.js-locales/lv.js' implicitly has an 'any' type."
-    },
-    "072af83912fd373522c4085ecf3769eb8df30e33": {
-      "file": "src/components/graphs/Plot.tsx",
-      "code": "TS7016",
-      "count": 1,
-      "message": "Could not find a declaration file for module 'plotly.js-locales/pl'. '/Users/tero/Projects/Kausal/kausal-paths-ui/node_modules/.pnpm/plotly.js-locales@3.5.0/node_modules/plotly.js-locales/pl.js' implicitly has an 'any' type."
-    },
-    "650e9e4babe9eb0e5dd7bf1d0e7be34f41d84490": {
-      "file": "src/components/graphs/Plot.tsx",
-      "code": "TS7016",
-      "count": 1,
-      "message": "Could not find a declaration file for module 'plotly.js-locales/sv'. '/Users/tero/Projects/Kausal/kausal-paths-ui/node_modules/.pnpm/plotly.js-locales@3.5.0/node_modules/plotly.js-locales/sv.js' implicitly has an 'any' type."
-    },
-    "53edd3400a9360e78e96af17f88bbdd872cd65b7": {
-      "file": "src/components/graphs/Plot.tsx",
-      "code": "TS7016",
-      "count": 1,
-      "message": "Could not find a declaration file for module 'plotly.js/dist/plotly-basic'. '/Users/tero/Projects/Kausal/kausal-paths-ui/node_modules/.pnpm/plotly.js@3.5.0_mapbox-gl@1.13.3/node_modules/plotly.js/dist/plotly-basic.js' implicitly has an 'any' type."
-    },
-    "e8db2f478295efcbd76c7cdc26ae40e81306f81a": {
-      "file": "src/components/Layout.tsx",
-      "code": "TS7006",
-      "count": 1,
-      "message": "Parameter 'page' implicitly has an 'any' type."
     },
     "a7ca7397817f5ac924f5b6432183a1342914f976": {
       "file": "src/components/pages/DashboardPage.tsx",


### PR DESCRIPTION
- Make sure all app internal links use Link component for basePath consistency
- Prepend framework name on model titles on framework instances
- When creating a framework instance, generate model identifier instead of asking the user