### PR TITLE
Prevent outcome node scenario filtering for non-NetZeroPlanner plans

### DIFF
--- a/src/components/pages/Page.tsx
+++ b/src/components/pages/Page.tsx
@@ -13,6 +13,7 @@ import { logApolloError } from '@common/logging/apollo';
 import type { PageQuery, PageQueryVariables } from '@/common/__generated__/graphql';
 import { activeGoalVar } from '@/common/cache';
 import { useTranslation } from '@/common/i18n';
+import { useFeatures } from '@/common/instance';
 import ErrorMessage from '@/components/common/ErrorMessage';
 import Error from '@/components/common/PathsError';
 import { StreamField } from '@/components/common/StreamField';
@@ -56,9 +57,10 @@ function Page(props: PageProps) {
   const { path, headerExtra } = props;
 
   const site = useSiteOrNull();
+  const { showRefreshPrompt } = useFeatures();
   const baselineScenario = site ? getBaselineScenario(site.scenarios) : undefined;
   const scenarios =
-    site && !!getProgressTrackingScenario(site.scenarios)
+    site && showRefreshPrompt && !!getProgressTrackingScenario(site.scenarios)
       ? ['default', 'progress_tracking', ...(baselineScenario ? [baselineScenario.id] : [])]
       : null;
   const activeGoal = useReactiveVar(activeGoalVar);


### PR DESCRIPTION
## Description
Previously we filtered the outcome node by scenarios if the progress tracking scenario existed, which was fine for pure NZP plans, but causes bugs when an instance using the progress tracker also uses new scenarios, branching away from NZP.

In future, we should use a separate feature flag for this, this is a quick fix