### PR TITLE
Make client-side API routing base-path aware

### DIFF
--- a/src/app/root/[domain]/[lang]/layout.tsx
+++ b/src/app/root/[domain]/[lang]/layout.tsx
@@ -224,6 +224,7 @@ export default function LangLayout(props: Props) {
               locale={params.lang}
               instanceIdentifier={ctx.instanceIdentifier}
               instanceHostname={ctx.instanceHostname}
+              basePath={ctx.basePath}
             >
               <InstanceProviders
                 siteContext={siteContext}

--- a/src/common/apollo-config.ts
+++ b/src/common/apollo-config.ts
@@ -54,6 +54,13 @@ export type PreviewMode = 'DRAFT' | 'PUBLISHED';
 export type ApolloClientOpts = {
   instanceHostname?: string;
   instanceIdentifier?: string;
+  /**
+   * Base path the instance is served under (e.g. `/modeling`), or `''` for
+   * instances served at the host root. On the client the GraphQL request goes
+   * through the Next.js proxy route, which is only reachable under this prefix
+   * when the host root belongs to a different app. See `getApolloClientConfig`.
+   */
+  basePath?: string;
   wildcardDomains?: string[];
   authorizationToken?: string | undefined;
   clientIp?: string | null;
@@ -272,7 +279,14 @@ export function getApolloClientConfig(opts: ApolloClientOpts): {
   cache: InMemoryCacheConfig;
 } {
   const ssrMode = typeof window === 'undefined';
-  const uri = ssrMode ? getPathsGraphQLUrl() : GRAPHQL_CLIENT_PROXY_PATH;
+  // On the server we talk to the backend directly via an absolute URL. On the
+  // client the request goes through the Next.js proxy route (`/api/graphql`).
+  // When the instance is served under a base path (e.g. `/modeling` on a domain
+  // whose root is owned by another app), a bare `/api/graphql` would be routed
+  // to that other app, so we prefix the proxy path with the instance base path.
+  // For root-hosted instances `basePath` is `''`, leaving the path unchanged.
+  const clientUri = `${opts.basePath ?? ''}${GRAPHQL_CLIENT_PROXY_PATH}`;
+  const uri = ssrMode ? getPathsGraphQLUrl() : clientUri;
 
   const httpLink = new HttpLink({
     uri,

--- a/src/components/providers/ApolloWrapper.tsx
+++ b/src/components/providers/ApolloWrapper.tsx
@@ -12,6 +12,8 @@ type Props = {
   locale: string;
   instanceIdentifier: string;
   instanceHostname: string;
+  /** Base path the instance is served under (e.g. `/modeling`), or `''` at the host root. */
+  basePath: string;
 } & React.PropsWithChildren;
 
 /**
@@ -27,11 +29,18 @@ function detectPreviewMode() {
   return null;
 }
 
-export function ApolloWrapper({ locale, instanceIdentifier, instanceHostname, children }: Props) {
+export function ApolloWrapper({
+  locale,
+  instanceIdentifier,
+  instanceHostname,
+  basePath,
+  children,
+}: Props) {
   const opts = {
     locale,
     instanceIdentifier,
     instanceHostname,
+    basePath,
     previewMode: detectPreviewMode,
   };
   const clientConfig = getApolloClientConfig(opts);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -345,6 +345,17 @@ async function proxy(req: NextRequest) {
   reqHeaders.set(BASE_PATH_HEADER, basePath);
   reqHeaders.set(REQUEST_CORRELATION_ID_HEADER, reqId);
   if (!shouldAddInstanceHeaders(match.parts)) {
+    // Non-page paths (api, static, _next, …). When the instance is served under
+    // a base path, the request arrives prefixed (e.g. `/modeling/api/graphql`)
+    // but the route handlers live at the root (`/api/graphql`). Rewrite to the
+    // base-path-stripped path (`match.path`) so the handler is reached.
+    // For root-hosted instances these paths are short-circuited earlier in
+    // `handleNonPagePaths`, so we only reach here when there's a prefix to strip.
+    if (basePath) {
+      const rewrittenUrl = new URL(match.path, req.url);
+      rewrittenUrl.search = nextUrl.search;
+      return NextResponse.rewrite(rewrittenUrl, reqInit);
+    }
     return NextResponse.next(reqInit);
   }
   if (!instances.length) {
@@ -377,7 +388,9 @@ async function proxy(req: NextRequest) {
   if (requiresAuth) {
     const sessionCookie = getSessionCookie(req);
     if (!sessionCookie) {
-      return NextResponse.redirect(new URL('/auth/sign-in', req.url));
+      // Keep the redirect within the instance base path (e.g. `/modeling/auth/sign-in`);
+      // `basePath` is `''` for root-hosted instances.
+      return NextResponse.redirect(new URL(`${basePath}/auth/sign-in`, req.url));
     }
   }
 


### PR DESCRIPTION
## Summary

The UI can serve an instance under a **base path** (e.g. `/modeling`) instead of
at the host root. The proxy middleware resolves the per-request base path, page
navigation honours it, and generated links are prefixed with it. **Client-side
data fetching did not honour it**, which breaks any instance mounted under a
non-root base path on a domain whose root is owned by a different application.

This PR makes the client-side GraphQL request base-path aware and adds the
middleware rewrite needed for the prefixed request to reach its route handler.

## Background / root cause

The Apollo client chooses its endpoint based on environment
(`src/common/apollo-config.ts`):

```ts
const uri = ssrMode ? getPathsGraphQLUrl() : GRAPHQL_CLIENT_PROXY_PATH;
```

- **Server-side render** → absolute backend URL. Host-independent, so the page
  shell always renders.
- **Browser** → the root-relative proxy path `/api/graphql`.

When an instance is served at the host root, that root-relative path resolves
to the instance and everything works — which is why this was never noticed: up
to now every instance has used `path: /`.

When an instance is mounted under a base path (e.g. `/modeling`) on a domain
whose **root belongs to another app**, the browser — sitting at
`https://<host>/modeling` — still fires its data requests to
`https://<host>/api/graphql`, i.e. the host **root**, outside the instance
prefix. Ingress routes only the base-path prefix to this app, so the request
lands on the *other* app at the root and returns a non-Paths response. The
result is a data/loading error in the UI even though the page shell rendered
fine.

There is a long-standing comment in `src/common/const.js` acknowledging the
intended behaviour was never wired up:

```js
export const GQL_PROXY_PATH = '/api/graphql'; // Prepend with the base path
```

## Changes

- **`src/common/apollo-config.ts`** — add an optional `basePath` to
  `ApolloClientOpts`; the client-side GraphQL URL becomes
  `` `${basePath}${GRAPHQL_CLIENT_PROXY_PATH}` ``. SSR continues to use the
  absolute backend URL. Root-hosted instances pass `''`, so their behaviour is
  unchanged.
- **`src/components/providers/ApolloWrapper.tsx`** — accept a `basePath` prop
  and thread it into the Apollo client options.
- **`src/app/root/[domain]/[lang]/layout.tsx`** — pass the instance base path
  (already read from the base-path header into the request context) into
  `ApolloWrapper`.
- **`src/proxy.ts`** — required companion fix. A non-page request under a base
  path now arrives prefixed (e.g. `/modeling/api/graphql`), but the route
  handlers live at the root (`/api/graphql`). The middleware already chomps the
  base path internally; it now **rewrites** such requests to the stripped path
  (preserving the query string) so the handler is reached. Previously the
  request fell through unrewritten and 404'd. Root-hosted instances are
  unaffected — they short-circuit earlier in `handleNonPagePaths`.
- **`src/proxy.ts`** — the unauthenticated sign-in redirect hard-coded
  `/auth/sign-in`; it now keeps the instance base-path prefix
  (`` `${basePath}/auth/sign-in` ``).

## Why two coordinated changes

Fixing only the client URL would send the browser to `/<basePath>/api/graphql`,
which has no matching route and 404s. Fixing only the middleware does nothing,
because the browser never requests the prefixed path. Both are required for a
base-path instance to fetch data.

## Remaining work (follow-up, not in this PR)

The **better-auth client** (`src/lib/auth-client.ts`) is still not base-path
aware: it is a module-level singleton with the default base URL, so it talks to
`/api/auth/*` at the host root. Unlike the Apollo client it cannot read the
per-request base path from React context/props, because the singleton is shared
across all instances and instantiated once at module load. Making auth work
under a non-root base path requires exposing the per-request base path to the
client (e.g. a small injected global) and verifying better-auth's
`baseURL`/`basePath` resolution semantics, so it is deferred.

The middleware rewrite in this PR already makes `/<basePath>/api/auth/*`
routable, so only the client target needs updating in the follow-up. Until
then:

- **Unauthenticated viewing** of a base-path instance works.
- **Login flows** on a base-path instance do not.

## Testing

- `eslint` (with baseline suppressions) passes on the changed files.
- `tsc -b` reports no new type errors in the changed files.
- Root-hosted instances: behaviour unchanged (base path resolves to `''`; the
  client URL and middleware paths are identical to before).
- Manual verification of a base-path instance recommended before relying on it
  in production: confirm the browser issues `POST /<basePath>/api/graphql` (not
  `/api/graphql`) and receives a valid Paths GraphQL response.

## Related issue
[Asana task](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1206157312069301?focus=true)
