### PR TITLE
Query and use impactOverview goal for wedge (instead of metric)

### DIFF
--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -3524,7 +3524,10 @@ export type ActionsForChooserQuery = (
 );
 
 export type ImpactOverviewDetailFragment = (
-  { id: string, graphType: string | null, label: string, costLabel: string | null, effectLabel: string | null, indicatorLabel: string | null, costCategoryLabel: string | null, effectCategoryLabel: string | null, description: string | null, stakeholderDimension: string | null, outcomeDimension: string | null, plotLimitForIndicator: number | null, effectNode: (
+  { id: string, graphType: string | null, label: string, costLabel: string | null, effectLabel: string | null, indicatorLabel: string | null, costCategoryLabel: string | null, effectCategoryLabel: string | null, description: string | null, stakeholderDimension: string | null, outcomeDimension: string | null, plotLimitForIndicator: number | null, goal: Array<(
+    { year: number, value: number }
+    & { __typename: 'NodeGoal' }
+  )>, effectNode: (
     { id: string, name: string, shortDescription: string | null, unit: (
       { id: string, short: string }
       & { __typename: 'UnitType' }
@@ -3619,7 +3622,10 @@ export type ImpactOverviewQueryVariables = Exact<{
 
 export type ImpactOverviewQuery = (
   { impactOverview: (
-    { id: string, graphType: string | null, label: string, costLabel: string | null, effectLabel: string | null, indicatorLabel: string | null, costCategoryLabel: string | null, effectCategoryLabel: string | null, description: string | null, stakeholderDimension: string | null, outcomeDimension: string | null, plotLimitForIndicator: number | null, effectNode: (
+    { id: string, graphType: string | null, label: string, costLabel: string | null, effectLabel: string | null, indicatorLabel: string | null, costCategoryLabel: string | null, effectCategoryLabel: string | null, description: string | null, stakeholderDimension: string | null, outcomeDimension: string | null, plotLimitForIndicator: number | null, goal: Array<(
+      { year: number, value: number }
+      & { __typename: 'NodeGoal' }
+    )>, effectNode: (
       { id: string, name: string, shortDescription: string | null, unit: (
         { id: string, short: string }
         & { __typename: 'UnitType' }

--- a/src/components/general/WedgeDiagram.tsx
+++ b/src/components/general/WedgeDiagram.tsx
@@ -298,7 +298,7 @@ export function WedgeDiagram({ data, actionLookup, isLoading, yearRange }: Props
 
   // Goals from the effectNode (target values for the indicator). Independent
   // of the wedge stack — rendered as connected dots overlaying the chart.
-  const goals = useMemo(() => data?.effectNode?.goals ?? [], [data]);
+  const goals = useMemo(() => data?.goal ?? [], [data]);
 
   // Union of years across wedge entries AND goal years, filtered to yearRange.
   // Including goal years means a goal at e.g. 2035 still gets a tick on the

--- a/src/queries/getImpactOverview.ts
+++ b/src/queries/getImpactOverview.ts
@@ -14,6 +14,10 @@ export const IMPACT_OVERVIEW_DETAIL_FRAGMENT = gql`
     stakeholderDimension
     outcomeDimension
     plotLimitForIndicator
+    goal {
+      year
+      value
+    }
     effectNode {
       id
       name


### PR DESCRIPTION
Update wedge diagram query and graph to use goal directly from impactOverview to make sure the unit matches with rest of the data